### PR TITLE
Change flycast alpha sorting to per-strip

### DIFF
--- a/RetroArch/.retroarch/config/Flycast/DC.opt
+++ b/RetroArch/.retroarch/config/Flycast/DC.opt
@@ -1,5 +1,5 @@
 reicast_allow_service_buttons = "disabled"
-reicast_alpha_sorting = "per-triangle (normal)"
+reicast_alpha_sorting = "per-strip (fast, least accurate)"
 reicast_analog_stick_deadzone = "15%"
 reicast_anisotropic_filtering = "4"
 reicast_boot_to_bios = "disabled"


### PR DESCRIPTION
Minor improvements to Dreamcast emulator performance, may cause graphical glitching in some rare cases but can set to per-triangle for games that don't work well with per-strip sorting