### PR TITLE
[Fix] default Ports launcher not setting cpufreq

### DIFF
--- a/Emus/PORTS/launch.sh
+++ b/Emus/PORTS/launch.sh
@@ -5,6 +5,9 @@ EMU_DIR="/mnt/SDCARD/Emus/PORTS"
 
 selected_option=$(grep "dowork 0x" "/tmp/log/messages" | tail -n 1 | sed -e 's/.*: \(.*\) dowork 0x.*/\1/')
 
+if [ -z "$selected_option" ]; then
+    selected_option="Balanced"
+fi
 $EMU_DIR/cpufreq.sh "$selected_option"
 
 PORTS_DIR=/mnt/SDCARD/Roms/PORTS


### PR DESCRIPTION
Not sure if just skip cpufreq.sh call when we use default launcher a better solution ?
Also, with my other PR, we don't have this issue as it use Balanced as default launcher but we may create an "Unchanged" launcher which don't call cpufreq anyway.