### PR TITLE
[Feature] Save your prefered launcher per game and per system

### DIFF
--- a/Emus/AMIGA/config.json
+++ b/Emus/AMIGA/config.json
@@ -5,7 +5,7 @@
   "iconlist": "ic-AMIGA-list.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/AMIGA.png",
   "themecolor": "FFFF88",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/AMIGA",
   "imgpath": "../../Imgs/AMIGA",
   "useswap": 1,

--- a/Emus/AMIGA/default.sh
+++ b/Emus/AMIGA/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/AMIGACD/config.json
+++ b/Emus/AMIGACD/config.json
@@ -3,7 +3,7 @@
   "icon": "/mnt/SDCARD/Icons/Default/Emus/AMIGACD.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/AMIGACD.png",
   "iconsel": "",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/AMIGACD",
   "imgpath": "../../Imgs/AMIGACD",
   "useswap": 0,

--- a/Emus/AMIGACD/default.sh
+++ b/Emus/AMIGACD/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/AMIGACDTV/config.json
+++ b/Emus/AMIGACDTV/config.json
@@ -3,7 +3,7 @@
   "icon": "/mnt/SDCARD/Icons/Default/Emus/AMIGACDTV.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/AMIGACDTV.png",
   "iconsel": "",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/AMIGACDTV",
   "imgpath": "../../Imgs/AMIGACDTV",
   "useswap": 0,

--- a/Emus/AMIGACDTV/default.sh
+++ b/Emus/AMIGACDTV/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/ARDUBOY/config.json
+++ b/Emus/ARDUBOY/config.json
@@ -3,7 +3,7 @@
   "icon": "/mnt/SDCARD/Icons/Default/Emus/ARDUBOY.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/ARDUBOY.png",
   "iconsel": "",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/ARDUBOY",
   "imgpath": "../../Imgs/ARDUBOY",
   "useswap": 0,

--- a/Emus/ARDUBOY/default.sh
+++ b/Emus/ARDUBOY/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/ATARI2600/config.json
+++ b/Emus/ATARI2600/config.json
@@ -5,7 +5,7 @@
   "iconlist": "ic-atari2600-32-n.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/ATARI2600.png",
   "themecolor": "AF7AC5",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/ATARI2600",
   "imgpath": "../../Imgs/ATARI2600",
   "useswap": 0,

--- a/Emus/ATARI2600/default.sh
+++ b/Emus/ATARI2600/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/ATARI5200/config.json
+++ b/Emus/ATARI5200/config.json
@@ -5,7 +5,7 @@
   "iconlist": "",
   "background": "/mnt/SDCARD/Backgrounds/Default/ATARI5200.png",
   "themecolor": "A569BD",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/ATARI5200",
   "imgpath": "../../Imgs/ATARI5200",
   "useswap": 0,

--- a/Emus/ATARI5200/default.sh
+++ b/Emus/ATARI5200/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/ATARI7800/config.json
+++ b/Emus/ATARI7800/config.json
@@ -5,7 +5,7 @@
   "iconlist": "ic-atari7800-32-n.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/ATARI7800.png",
   "themecolor": "A569BD",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/ATARI7800",
   "imgpath": "../../Imgs/ATARI7800",
   "useswap": 0,

--- a/Emus/ATARI7800/default.sh
+++ b/Emus/ATARI7800/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/ATARI800/config.json
+++ b/Emus/ATARI800/config.json
@@ -5,7 +5,7 @@
   "iconlist": "ic-atari2600-32-n.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/ATARI800.png",
   "themecolor": "AF7AC5",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/ATARI800",
   "imgpath": "../../Imgs/ATARI800",
   "useswap": 0,

--- a/Emus/ATARI800/default.sh
+++ b/Emus/ATARI800/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/ATARIST/config.json
+++ b/Emus/ATARIST/config.json
@@ -3,7 +3,7 @@
   "icon": "/mnt/SDCARD/Icons/Default/Emus/ATARIST.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/ATARIST.png",
   "iconsel": "",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/ATARIST",
   "imgpath": "../../Imgs/ATARIST",
   "useswap": 0,

--- a/Emus/ATARIST/default.sh
+++ b/Emus/ATARIST/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/ATOMISWAVE/config.json
+++ b/Emus/ATOMISWAVE/config.json
@@ -6,7 +6,7 @@
   "effectsh": "",
   "background": "/mnt/SDCARD/Backgrounds/Default/ATOMISWAVE.png",
   "themecolor": "FFFFFF",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/ATOMISWAVE",
   "imgpath": "../../Imgs/ATOMISWAVE",
   "useswap": 1,

--- a/Emus/ATOMISWAVE/default.sh
+++ b/Emus/ATOMISWAVE/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/ATOMISWAVE/launch_standalone.sh
+++ b/Emus/ATOMISWAVE/launch_standalone.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+source /mnt/SDCARD/System/usr/trimui/scripts/common_launcher.sh
 echo $0 $*
 
 EMU_DIR=/mnt/SDCARD/Emus/ATOMISWAVE

--- a/Emus/C64/config.json
+++ b/Emus/C64/config.json
@@ -5,7 +5,7 @@
   "iconlist": "ic-C64-list.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/C64.png",
   "themecolor": "FFFF88",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/C64",
   "imgpath": "../../Imgs/C64",
   "useswap": 1,

--- a/Emus/C64/default.sh
+++ b/Emus/C64/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/CANNONBALL/config.json
+++ b/Emus/CANNONBALL/config.json
@@ -5,7 +5,7 @@
   "iconlist": "ic-C64-list.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/CANNONBALL.png",
   "themecolor": "FFFF88",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/CANNONBALL",
   "imgpath": "../../Imgs/CANNONBALL",
   "useswap": 1,

--- a/Emus/CANNONBALL/default.sh
+++ b/Emus/CANNONBALL/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/CAVESTORY/config.json
+++ b/Emus/CAVESTORY/config.json
@@ -5,7 +5,7 @@
   "iconlist": "ic-C64-list.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/CAVESTORY.png",
   "themecolor": "FFFF88",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/CAVESTORY",
   "imgpath": "../../Imgs/CAVESTORY",
   "useswap": 1,

--- a/Emus/CAVESTORY/default.sh
+++ b/Emus/CAVESTORY/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/CHAILOVE/config.json
+++ b/Emus/CHAILOVE/config.json
@@ -5,7 +5,7 @@
   "iconlist": "ic-atari2600-32-n.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/CHAILOVE.png",
   "themecolor": "AF7AC5",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/CHAILOVE",
   "imgpath": "../../Imgs/CHAILOVE",
   "useswap": 0,

--- a/Emus/CHAILOVE/default.sh
+++ b/Emus/CHAILOVE/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/CHANNELF/config.json
+++ b/Emus/CHANNELF/config.json
@@ -5,7 +5,7 @@
   "iconlist": "ic-C64-list.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/CHANNELF.png",
   "themecolor": "FFFF88",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/CHANNELF",
   "imgpath": "../../Imgs/CHANNELF",
   "useswap": 1,

--- a/Emus/CHANNELF/default.sh
+++ b/Emus/CHANNELF/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/COLECO/config.json
+++ b/Emus/COLECO/config.json
@@ -5,7 +5,7 @@
   "iconlist": "",
   "background": "/mnt/SDCARD/Backgrounds/Default/COLECO.png",
   "themecolor": "FFFF88",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/COLECO",
   "imgpath": "../../Imgs/COLECO",
   "useswap": 1,

--- a/Emus/COLECO/default.sh
+++ b/Emus/COLECO/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/COLSGM/config.json
+++ b/Emus/COLSGM/config.json
@@ -5,7 +5,7 @@
   "iconlist": "",
   "background": "/mnt/SDCARD/Backgrounds/Default/COLSGM.png",
   "themecolor": "FFFF88",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/COLSGM",
   "imgpath": "../../Imgs/COLSGM",
   "useswap": 1,

--- a/Emus/COLSGM/default.sh
+++ b/Emus/COLSGM/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/CPC/config.json
+++ b/Emus/CPC/config.json
@@ -3,7 +3,7 @@
   "icon": "/mnt/SDCARD/Icons/Default/Emus/CPC.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/CPC.png",
   "iconsel": "",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/CPC",
   "imgpath": "../../Imgs/CPC",
   "useswap": 0,

--- a/Emus/CPC/default.sh
+++ b/Emus/CPC/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/CPET/config.json
+++ b/Emus/CPET/config.json
@@ -5,7 +5,7 @@
   "iconlist": "ic-C64-list.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/CPET.png",
   "themecolor": "FFFF88",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/CPET",
   "imgpath": "../../Imgs/CPET",
   "useswap": 1,

--- a/Emus/CPET/default.sh
+++ b/Emus/CPET/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/CPLUS4/config.json
+++ b/Emus/CPLUS4/config.json
@@ -5,7 +5,7 @@
   "iconlist": "ic-C64-list.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/CPLUS4.png",
   "themecolor": "FFFF88",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/CPLUS4",
   "imgpath": "../../Imgs/CPLUS4",
   "useswap": 1,

--- a/Emus/CPLUS4/default.sh
+++ b/Emus/CPLUS4/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/CPS1/config.json
+++ b/Emus/CPS1/config.json
@@ -5,7 +5,7 @@
   "iconlist": "ic-cps1-32-n.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/CPS1.png",
   "themecolor": "0000FF",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/CPS1",
   "imgpath": "../../Imgs/CPS1",
   "useswap": 1,

--- a/Emus/CPS1/default.sh
+++ b/Emus/CPS1/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/CPS2/config.json
+++ b/Emus/CPS2/config.json
@@ -6,7 +6,7 @@
   "background": "/mnt/SDCARD/Backgrounds/Default/CPS2.png",
   "themecolor": "FFFF00",
   "effectsh": "effect.sh",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/CPS2",
   "imgpath": "../../Imgs/CPS2",
   "useswap": 1,

--- a/Emus/CPS2/default.sh
+++ b/Emus/CPS2/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/CPS3/config.json
+++ b/Emus/CPS3/config.json
@@ -6,7 +6,7 @@
   "background": "/mnt/SDCARD/Backgrounds/Default/CPS3.png",
   "themecolor": "FF4400",
   "effectsh": "effect.sh",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/CPS3",
   "imgpath": "../../Imgs/CPS3",
   "useswap": 1,

--- a/Emus/CPS3/default.sh
+++ b/Emus/CPS3/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/DAPHNE/config.json
+++ b/Emus/DAPHNE/config.json
@@ -1,7 +1,7 @@
 {
   "label": "Daphne",
   "icon": "/mnt/SDCARD/Icons/Default/Emus/DAPHNE.png",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/DAPHNE/roms",
   "imgpath": "../../Imgs/DAPHNE",
   "useswap": 1,

--- a/Emus/DAPHNE/default.sh
+++ b/Emus/DAPHNE/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/DC/config.json
+++ b/Emus/DC/config.json
@@ -6,7 +6,7 @@
   "effectsh": "effect.sh",
   "background": "/mnt/SDCARD/Backgrounds/Default/DC.png",
   "themecolor": "FFFFFF",
-  "launch": "flycast.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/DC",
   "imgpath": "../../Imgs/DC",
   "useswap": 1,

--- a/Emus/DC/default.sh
+++ b/Emus/DC/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/DC/flycast_standalone.sh
+++ b/Emus/DC/flycast_standalone.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+source /mnt/SDCARD/System/usr/trimui/scripts/common_launcher.sh
 echo $0 $*
 
 EMU_DIR=/mnt/SDCARD/Emus/DC

--- a/Emus/DINOTHAWR/config.json
+++ b/Emus/DINOTHAWR/config.json
@@ -5,7 +5,7 @@
   "iconlist": "ic-C64-list.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/DINOTHAWR.png",
   "themecolor": "FFFF88",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/DINOTHAWR",
   "imgpath": "../../Imgs/DINOTHAWR",
   "useswap": 1,

--- a/Emus/DINOTHAWR/default.sh
+++ b/Emus/DINOTHAWR/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/DOOM/config.json
+++ b/Emus/DOOM/config.json
@@ -5,7 +5,7 @@
   "iconlist": "ic-C64-list.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/DOOM.png",
   "themecolor": "FFFF88",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/DOOM",
   "imgpath": "../../Imgs/DOOM",
   "useswap": 1,

--- a/Emus/DOOM/default.sh
+++ b/Emus/DOOM/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/DOS/config.json
+++ b/Emus/DOS/config.json
@@ -5,7 +5,7 @@
   "iconlist": "ic-dos-list.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/DOS.png",
   "themecolor": "FFFF88",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/DOS",
   "imgpath": "../../Imgs/DOS",
   "useswap": 1,

--- a/Emus/DOS/default.sh
+++ b/Emus/DOS/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/EASYRPG/config.json
+++ b/Emus/EASYRPG/config.json
@@ -3,7 +3,7 @@
   "icon": "/mnt/SDCARD/Icons/Default/Emus/EASYRPG.png",
   "iconsel": "",
   "background": "/mnt/SDCARD/Backgrounds/Default/EASYRPG.png",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/EASYRPG",
   "imgpath": "../../Imgs/EASYRPG",
   "useswap": 0,

--- a/Emus/EASYRPG/default.sh
+++ b/Emus/EASYRPG/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/ENTERPRISE/config.json
+++ b/Emus/ENTERPRISE/config.json
@@ -5,7 +5,7 @@
   "iconlist": "ic-C64-list.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/ENTERPRISE.png",
   "themecolor": "FFFF88",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/ENTERPRISE",
   "imgpath": "../../Imgs/ENTERPRISE",
   "useswap": 1,

--- a/Emus/ENTERPRISE/default.sh
+++ b/Emus/ENTERPRISE/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/FBNEO/config.json
+++ b/Emus/FBNEO/config.json
@@ -4,7 +4,7 @@
   "iconsel": "",
   "background": "/mnt/SDCARD/Backgrounds/Default/FBNEO.png",
   "themecolor": "EC7063",
-  "launch": "FBNEO.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/FBNEO",
   "imgpath": "../../Imgs/FBNEO",
   "useswap": 1,

--- a/Emus/FBNEO/default.sh
+++ b/Emus/FBNEO/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/FC/config.json
+++ b/Emus/FC/config.json
@@ -3,7 +3,7 @@
   "icon": "/mnt/SDCARD/Icons/Default/Emus/FC.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/FC.png",
   "themecolor": "00FF88",
-  "launch": "fceumm.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/FC",
   "imgpath": "../../Imgs/FC",
   "useswap": 1,

--- a/Emus/FC/default.sh
+++ b/Emus/FC/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/FDS/config.json
+++ b/Emus/FDS/config.json
@@ -3,7 +3,7 @@
   "icon": "/mnt/SDCARD/Icons/Default/Emus/FDS.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/FDS.png",
   "iconsel": "",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/FDS",
   "imgpath": "../../Imgs/FDS",
   "useswap": 0,

--- a/Emus/FDS/default.sh
+++ b/Emus/FDS/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/FLASHBACK/config.json
+++ b/Emus/FLASHBACK/config.json
@@ -5,7 +5,7 @@
   "iconlist": "ic-C64-list.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/FLASHBACK.png",
   "themecolor": "FFFF88",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/FLASHBACK",
   "imgpath": "../../Imgs/FLASHBACK",
   "useswap": 1,

--- a/Emus/FLASHBACK/default.sh
+++ b/Emus/FLASHBACK/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/GB/config.json
+++ b/Emus/GB/config.json
@@ -3,7 +3,7 @@
   "icon": "/mnt/SDCARD/Icons/Default/Emus/GB.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/GB.png",
   "themecolor": "00FF88",
-  "launch": "gambatte.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/GB",
   "imgpath": "../../Imgs/GB",
   "useswap": 1,

--- a/Emus/GB/default.sh
+++ b/Emus/GB/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/GBA/config.json
+++ b/Emus/GBA/config.json
@@ -3,7 +3,7 @@
   "icon": "/mnt/SDCARD/Icons/Default/Emus/GBA.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/GBA.png",
   "themecolor": "FF00FF",
-  "launch": "mgba.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/GBA",
   "imgpath": "../../Imgs/GBA",
   "useswap": 0,
@@ -28,8 +28,8 @@
       "launch": "vbanext.sh"
     },
     {
-       "name": "mGBA - Standalone",
-       "launch": "mgba_standalone.sh"
+      "name": "mGBA - Standalone",
+      "launch": "mgba_standalone.sh"
     }
   ]
 }

--- a/Emus/GBA/default.sh
+++ b/Emus/GBA/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/GBA/mgba_standalone.sh
+++ b/Emus/GBA/mgba_standalone.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+source /mnt/SDCARD/System/usr/trimui/scripts/common_launcher.sh
 echo $0 $*
 
 EMU_DIR=/mnt/SDCARD/Emus/GBA

--- a/Emus/GBC/config.json
+++ b/Emus/GBC/config.json
@@ -3,7 +3,7 @@
   "icon": "/mnt/SDCARD/Icons/Default/Emus/GBC.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/GBC.png",
   "themecolor": "00FF88",
-  "launch": "gambatte.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/GBC",
   "imgpath": "../../Imgs/GBC",
   "useswap": 1,

--- a/Emus/GBC/default.sh
+++ b/Emus/GBC/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/GG/config.json
+++ b/Emus/GG/config.json
@@ -5,7 +5,7 @@
   "iconlist": "ic-GG-list.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/GG.png",
   "themecolor": "FFFF88",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/GG",
   "imgpath": "../../Imgs/GG",
   "useswap": 1,

--- a/Emus/GG/default.sh
+++ b/Emus/GG/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/GW/config.json
+++ b/Emus/GW/config.json
@@ -5,7 +5,7 @@
   "iconlist": "ic-GW-list.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/GW.png",
   "themecolor": "FFFF88",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/GW",
   "imgpath": "../../Imgs/GW",
   "useswap": 1,

--- a/Emus/GW/default.sh
+++ b/Emus/GW/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/INTELLIVISION/config.json
+++ b/Emus/INTELLIVISION/config.json
@@ -3,7 +3,7 @@
   "icon": "/mnt/SDCARD/Icons/Default/Emus/INTELLIVISION.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/INTELLIVISION.png",
   "iconsel": "",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/INTELLIVISION",
   "imgpath": "../../Imgs/INTELLIVISION",
   "useswap": 0,

--- a/Emus/INTELLIVISION/default.sh
+++ b/Emus/INTELLIVISION/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/LOWRESNX/config.json
+++ b/Emus/LOWRESNX/config.json
@@ -5,7 +5,7 @@
   "iconlist": "ic-LOWRESNX-list.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/LOWRESNX.png",
   "themecolor": "FFFF88",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/LOWRESNX",
   "imgpath": "../../Imgs/LOWRESNX",
   "useswap": 1,

--- a/Emus/LOWRESNX/default.sh
+++ b/Emus/LOWRESNX/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/LUTRO/config.json
+++ b/Emus/LUTRO/config.json
@@ -3,7 +3,7 @@
   "icon": "/mnt/SDCARD/Icons/Default/Emus/LUTRO.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/LUTRO.png",
   "iconsel": "",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/LUTRO",
   "imgpath": "../../Imgs/LUTRO",
   "useswap": 0,

--- a/Emus/LUTRO/default.sh
+++ b/Emus/LUTRO/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/LYNX/config.json
+++ b/Emus/LYNX/config.json
@@ -5,7 +5,7 @@
   "iconlist": "ic-LYNX-list.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/LYNX.png",
   "themecolor": "FFFF88",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/LYNX",
   "imgpath": "../../Imgs/LYNX",
   "useswap": 1,

--- a/Emus/LYNX/default.sh
+++ b/Emus/LYNX/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/MAME/config.json
+++ b/Emus/MAME/config.json
@@ -3,7 +3,7 @@
   "icon": "/mnt/SDCARD/Icons/Default/Emus/MAME.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/MAME.png",
   "themecolor": "00FF88",
-  "launch": "mame.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/MAME",
   "imgpath": "../../Imgs/MAME",
   "useswap": 1,

--- a/Emus/MAME/default.sh
+++ b/Emus/MAME/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/MAME2003PLUS/config.json
+++ b/Emus/MAME2003PLUS/config.json
@@ -5,7 +5,7 @@
   "iconlist": "ic-mame-plus-list.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/MAME2003PLUS.png",
   "themecolor": "00CCFF",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/MAME2003PLUS",
   "imgpath": "../../Imgs/MAME2003PLUS",
   "useswap": 1,

--- a/Emus/MAME2003PLUS/default.sh
+++ b/Emus/MAME2003PLUS/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/MAME2010/config.json
+++ b/Emus/MAME2010/config.json
@@ -5,7 +5,7 @@
   "iconlist": "ic-mame-plus-list.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/MAME2010.png",
   "themecolor": "00CCFF",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/MAME2010",
   "imgpath": "../../Imgs/MAME2010",
   "useswap": 1,

--- a/Emus/MAME2010/default.sh
+++ b/Emus/MAME2010/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/MD/config.json
+++ b/Emus/MD/config.json
@@ -5,7 +5,7 @@
   "iconlist": "ic-MD-32-n.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/MD.png",
   "themecolor": "0088CF",
-  "launch": "picodrive.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/MD",
   "imgpath": "../../Imgs/MD",
   "useswap": 0,

--- a/Emus/MD/default.sh
+++ b/Emus/MD/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/MDMSU/config.json
+++ b/Emus/MDMSU/config.json
@@ -5,7 +5,7 @@
   "iconlist": "",
   "background": "/mnt/SDCARD/Backgrounds/Default/MDMSU.png",
   "themecolor": "0088CF",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/MDMSU",
   "imgpath": "../../Imgs/MDMSU",
   "useswap": 0,

--- a/Emus/MDMSU/default.sh
+++ b/Emus/MDMSU/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/MEGADUCK/config.json
+++ b/Emus/MEGADUCK/config.json
@@ -5,7 +5,7 @@
   "iconlist": "",
   "background": "/mnt/SDCARD/Backgrounds/Default/MEGADUCK.png",
   "themecolor": "FF0000",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/MEGADUCK",
   "imgpath": "../../Imgs/MEGADUCK",
   "useswap": 0,

--- a/Emus/MEGADUCK/default.sh
+++ b/Emus/MEGADUCK/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/MS/config.json
+++ b/Emus/MS/config.json
@@ -4,7 +4,7 @@
   "iconsel": "",
   "background": "/mnt/SDCARD/Backgrounds/Default/MS.png",
   "themecolor": "740009",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/MS",
   "imgpath": "../../Imgs/MS",
   "useswap": 0,

--- a/Emus/MS/default.sh
+++ b/Emus/MS/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/MSX/config.json
+++ b/Emus/MSX/config.json
@@ -5,7 +5,7 @@
   "iconlist": "ic-MSX-list.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/MSX.png",
   "themecolor": "FFFF88",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/MSX",
   "imgpath": "../../Imgs/MSX",
   "useswap": 1,

--- a/Emus/MSX/default.sh
+++ b/Emus/MSX/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/MSX2/config.json
+++ b/Emus/MSX2/config.json
@@ -5,7 +5,7 @@
   "iconlist": "ic-MSX-list.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/MSX2.png",
   "themecolor": "FFFF88",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/MSX2",
   "imgpath": "../../Imgs/MSX2",
   "useswap": 1,

--- a/Emus/MSX2/default.sh
+++ b/Emus/MSX2/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/N64/config.json
+++ b/Emus/N64/config.json
@@ -5,7 +5,7 @@
   "iconlist": "ic-n64-32-n.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/N64.png",
   "themecolor": "FFFF88",
-  "launch": "paralleln64.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/N64",
   "imgpath": "../../Imgs/N64",
   "useswap": 1,

--- a/Emus/N64/default.sh
+++ b/Emus/N64/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/N64/mupen64plus_standalone.sh
+++ b/Emus/N64/mupen64plus_standalone.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+source /mnt/SDCARD/System/usr/trimui/scripts/common_launcher.sh
 echo $0 $*
 
 EMU_DIR=/mnt/SDCARD/Emus/N64/mupen64plus

--- a/Emus/N64DD/config.json
+++ b/Emus/N64DD/config.json
@@ -5,7 +5,7 @@
   "iconlist": "ic-n64-32-n.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/N64DD.png",
   "themecolor": "FFFF88",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/N64DD",
   "imgpath": "../../Imgs/N64DD",
   "useswap": 1,

--- a/Emus/N64DD/default.sh
+++ b/Emus/N64DD/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/N64DD/launch.sh
+++ b/Emus/N64DD/launch.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+source /mnt/SDCARD/System/usr/trimui/scripts/common_launcher.sh
 
 echo $0 $*
 

--- a/Emus/NAOMI/config.json
+++ b/Emus/NAOMI/config.json
@@ -6,7 +6,7 @@
   "effectsh": "effect.sh",
   "background": "/mnt/SDCARD/Backgrounds/Default/NAOMI.png",
   "themecolor": "FFFFFF",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/NAOMI",
   "imgpath": "../../Imgs/NAOMI",
   "useswap": 1,

--- a/Emus/NAOMI/default.sh
+++ b/Emus/NAOMI/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/NAOMI/launch_standalone.sh
+++ b/Emus/NAOMI/launch_standalone.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+source /mnt/SDCARD/System/usr/trimui/scripts/common_launcher.sh
 echo $0 $*
 
 EMU_DIR=/mnt/SDCARD/Emus/NAOMI

--- a/Emus/NDS/config.json
+++ b/Emus/NDS/config.json
@@ -1,25 +1,24 @@
 {
-    "label": "N. NDS",
-    "icon": "/mnt/SDCARD/Icons/Default/Emus/NDS.png",
-    "launch": "launch.sh",
-    "background": "/mnt/SDCARD/Backgrounds/Default/NDS.png",
-    "themecolor":"FF8800",
-    "iconsel":"",
-    "rompath":"../../Roms/NDS",
-    "imgpath":"../../Imgs/NDS",
-    "useswap":1,
-    "shortname":1,
-    "hidebios":1,
-    "extlist": "nds|zip|7z|rar",
-    "launchlist": [
-        {
-            "name": "Drastic - SDL2 MOD(凯)",
-            "launch": "launch.sh"
-        },
-        {
-            "name": "Drastic - No MOD      ",
-            "launch": "launch_original.sh"
-        }
-    ]
+  "label": "N. NDS",
+  "icon": "/mnt/SDCARD/Icons/Default/Emus/NDS.png",
+  "launch": "default.sh",
+  "background": "/mnt/SDCARD/Backgrounds/Default/NDS.png",
+  "themecolor": "FF8800",
+  "iconsel": "",
+  "rompath": "../../Roms/NDS",
+  "imgpath": "../../Imgs/NDS",
+  "useswap": 1,
+  "shortname": 1,
+  "hidebios": 1,
+  "extlist": "nds|zip|7z|rar",
+  "launchlist": [
+    {
+      "name": "Drastic - SDL2 MOD(凯)",
+      "launch": "launch.sh"
+    },
+    {
+      "name": "Drastic - No MOD      ",
+      "launch": "launch_original.sh"
+    }
+  ]
 }
-    

--- a/Emus/NDS/default.sh
+++ b/Emus/NDS/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/NDS/launch.sh
+++ b/Emus/NDS/launch.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+source /mnt/SDCARD/System/usr/trimui/scripts/common_launcher.sh
 echo $0 $*
 progdir=`dirname "$0"`/drastic
 cd $progdir

--- a/Emus/NDS/launch_original.sh
+++ b/Emus/NDS/launch_original.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+source /mnt/SDCARD/System/usr/trimui/scripts/common_launcher.sh
 echo $0 $*
 progdir=`dirname "$0"`/drastic
 cd $progdir

--- a/Emus/NEOCD/config.json
+++ b/Emus/NEOCD/config.json
@@ -5,7 +5,7 @@
   "iconlist": "ic-NEOCD-list.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/NEOCD.png",
   "themecolor": "FFFF88",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/NEOCD",
   "imgpath": "../../Imgs/NEOCD",
   "useswap": 1,

--- a/Emus/NEOCD/default.sh
+++ b/Emus/NEOCD/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/NEOGEO/config.json
+++ b/Emus/NEOGEO/config.json
@@ -5,7 +5,7 @@
   "iconlist": "ic-neogeo-32-n.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/NEOGEO.png",
   "themecolor": "FFD200",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/NEOGEO",
   "imgpath": "../../Imgs/NEOGEO",
   "gamelist": "../../Roms/NEOGEO/gamelist.xml",

--- a/Emus/NEOGEO/default.sh
+++ b/Emus/NEOGEO/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/NGC/config.json
+++ b/Emus/NGC/config.json
@@ -3,7 +3,7 @@
   "icon": "/mnt/SDCARD/Icons/Default/Emus/NGC.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/NGC.png",
   "iconsel": "",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/NGC",
   "imgpath": "../../Imgs/NGC",
   "useswap": 0,

--- a/Emus/NGC/default.sh
+++ b/Emus/NGC/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/NGP/config.json
+++ b/Emus/NGP/config.json
@@ -5,7 +5,7 @@
   "iconlist": "ic-NGP-32-n.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/NGP.png",
   "themecolor": "FFFFFF",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/NGP",
   "imgpath": "../../Imgs/NGP",
   "useswap": 0,

--- a/Emus/NGP/default.sh
+++ b/Emus/NGP/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/OPENBOR/config.json
+++ b/Emus/OPENBOR/config.json
@@ -4,7 +4,7 @@
   "background": "/mnt/SDCARD/Backgrounds/Default/OPENBOR.png",
   "iconsmall": "ic-openbor.png",
   "iconlist": "ic-openbor.png",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/OPENBOR",
   "imgpath": "../../Imgs/OPENBOR",
   "useswap": 1,

--- a/Emus/OPENBOR/default.sh
+++ b/Emus/OPENBOR/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/PALMOS/config.json
+++ b/Emus/PALMOS/config.json
@@ -5,7 +5,7 @@
   "iconlist": "ic-C64-list.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/PALMOS.png",
   "themecolor": "FFFF88",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/PALMOS",
   "imgpath": "../../Imgs/PALMOS",
   "useswap": 1,

--- a/Emus/PALMOS/default.sh
+++ b/Emus/PALMOS/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/PANASONIC/config.json
+++ b/Emus/PANASONIC/config.json
@@ -5,7 +5,7 @@
   "iconlist": "ic-OPERA-list.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/PANASONIC.png",
   "themecolor": "FFFF88",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/PANASONIC",
   "imgpath": "../../Imgs/PANASONIC",
   "useswap": 1,

--- a/Emus/PANASONIC/default.sh
+++ b/Emus/PANASONIC/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/PC88/config.json
+++ b/Emus/PC88/config.json
@@ -5,7 +5,7 @@
   "iconlist": "ic-cps1-32-n.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/PC88.png",
   "themecolor": "0000FF",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/PC88",
   "imgpath": "../../Imgs/PC88",
   "useswap": 1,

--- a/Emus/PC88/default.sh
+++ b/Emus/PC88/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/PC88/launch.sh
+++ b/Emus/PC88/launch.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+source /mnt/SDCARD/System/usr/trimui/scripts/common_launcher.sh
 RA_DIR=/mnt/SDCARD/RetroArch
 EMU_DIR=/mnt/SDCARD/Emus/PC88
 cd $RA_DIR/

--- a/Emus/PC98/config.json
+++ b/Emus/PC98/config.json
@@ -5,7 +5,7 @@
   "iconlist": "ic-cps1-32-n.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/PC98.png",
   "themecolor": "0000FF",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/PC98",
   "imgpath": "../../Imgs/PC98",
   "useswap": 1,

--- a/Emus/PC98/default.sh
+++ b/Emus/PC98/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/PC98/launch.sh
+++ b/Emus/PC98/launch.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+source /mnt/SDCARD/System/usr/trimui/scripts/common_launcher.sh
 RA_DIR=/mnt/SDCARD/RetroArch
 EMU_DIR=/mnt/SDCARD/Emus/PC98
 cd $RA_DIR/

--- a/Emus/PCE/config.json
+++ b/Emus/PCE/config.json
@@ -5,7 +5,7 @@
   "iconlist": "ic-PCE-32-n.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/PCE.png",
   "themecolor": "EA483F",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/PCE",
   "imgpath": "../../Imgs/PCE",
   "useswap": 0,

--- a/Emus/PCE/default.sh
+++ b/Emus/PCE/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/PCECD/config.json
+++ b/Emus/PCECD/config.json
@@ -3,7 +3,7 @@
   "icon": "/mnt/SDCARD/Icons/Default/Emus/PCECD.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/PCECD.png",
   "iconsel": "",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/PCECD",
   "imgpath": "../../Imgs/PCECD",
   "useswap": 0,

--- a/Emus/PCECD/default.sh
+++ b/Emus/PCECD/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/PCFX/config.json
+++ b/Emus/PCFX/config.json
@@ -5,7 +5,7 @@
   "iconlist": "",
   "background": "/mnt/SDCARD/Backgrounds/Default/PCFX.png",
   "themecolor": "FFFF88",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/PCFX",
   "imgpath": "../../Imgs/PCFX",
   "useswap": 1,

--- a/Emus/PCFX/default.sh
+++ b/Emus/PCFX/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/PGM/config.json
+++ b/Emus/PGM/config.json
@@ -4,7 +4,7 @@
   "iconsel": "",
   "background": "/mnt/SDCARD/Backgrounds/Default/PGM.png",
   "themecolor": "FAF792",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/PGM",
   "imgpath": "../../Imgs/PGM",
   "useswap": 1,

--- a/Emus/PGM/default.sh
+++ b/Emus/PGM/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/PICO/Pico8 Wrapper - Splore.sh
+++ b/Emus/PICO/Pico8 Wrapper - Splore.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+source /mnt/SDCARD/System/usr/trimui/scripts/common_launcher.sh
 export picodir=/mnt/SDCARD/Emus/PICO/PICO8_Wrapper
 cd $picodir
 export PATH=$PATH:$PWD/bin

--- a/Emus/PICO/Pico8 Wrapper.sh
+++ b/Emus/PICO/Pico8 Wrapper.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+source /mnt/SDCARD/System/usr/trimui/scripts/common_launcher.sh
 export picodir=/mnt/SDCARD/Emus/PICO/PICO8_Wrapper
 cd $picodir
 export PATH=$PATH:$PWD/bin

--- a/Emus/PICO/config.json
+++ b/Emus/PICO/config.json
@@ -3,7 +3,7 @@
   "icon": "/mnt/SDCARD/Icons/Default/Emus/PICO.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/PICO.png",
   "themecolor": "00FF88",
-  "launch": "fake08.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/PICO",
   "imgpath": "../../Imgs/PICO",
   "useswap": 1,

--- a/Emus/PICO/default.sh
+++ b/Emus/PICO/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/POKEMINI/config.json
+++ b/Emus/POKEMINI/config.json
@@ -5,7 +5,7 @@
   "iconlist": "",
   "background": "/mnt/SDCARD/Backgrounds/Default/POKEMINI.png",
   "themecolor": "FFFF88",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/POKEMINI",
   "imgpath": "../../Imgs/POKEMINI",
   "useswap": 1,

--- a/Emus/POKEMINI/default.sh
+++ b/Emus/POKEMINI/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/PORTS/config.json
+++ b/Emus/PORTS/config.json
@@ -5,25 +5,25 @@
   "iconlist": "",
   "background": "/mnt/SDCARD/Backgrounds/Default/PORTS.png",
   "themecolor": "61A8DD",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/PORTS",
   "imgpath": "../../Imgs/PORTS",
   "useswap": 1,
   "shortname": 0,
   "hidebios": 1,
-    "extlist":"sh",
-    "launchlist": [
-        {
-            "name": "Battery Saver",
-            "launch": "launch.sh"
-        },
-        {
-            "name": "Balanced",
-            "launch": "launch.sh"
-        },
-        {
-            "name": "High Performance",
-            "launch": "launch.sh"
-        }
-    ]
+  "extlist": "sh",
+  "launchlist": [
+    {
+      "name": "Battery Saver",
+      "launch": "launch.sh"
+    },
+    {
+      "name": "Balanced",
+      "launch": "launch.sh"
+    },
+    {
+      "name": "High Performance",
+      "launch": "launch.sh"
+    }
+  ]
 }

--- a/Emus/PORTS/default.sh
+++ b/Emus/PORTS/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/PS/config.json
+++ b/Emus/PS/config.json
@@ -5,7 +5,7 @@
   "iconlist": "ic-PS-32-n.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/PS.png",
   "themecolor": "00FF00",
-  "launch": "pcsx.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/PS",
   "imgpath": "../../Imgs/PS",
   "useswap": 1,

--- a/Emus/PS/default.sh
+++ b/Emus/PS/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/PSP/config.json
+++ b/Emus/PSP/config.json
@@ -2,7 +2,7 @@
   "label": "PSP",
   "label.ch.lang": "PSP",
   "icon": "/mnt/SDCARD/Icons/Default/Emus/PSP.png",
-  "launch": "launch_1.17.1_gl.sh",
+  "launch": "default.sh",
   "background": "/mnt/SDCARD/Backgrounds/Default/PSP.png",
   "themecolor": "64A8BD",
   "iconsel": "",
@@ -37,7 +37,7 @@
       "name.ch.lang": "PPSSPP正常模式 - Perf.",
       "launch": "launch_1.17.1_gl.sh"
     },
-	{
+    {
       "name": "PPSSPP 1.17.1 - Vulkan - Perf.",
       "name.ch.lang": "PPSSPP性能模式 - Perf.",
       "launch": "launch_1.17.1_vulkan.sh"
@@ -46,6 +46,6 @@
       "name": "PPSSPP-1.5.4 - Perf.",
       "name.ch.lang": "PPSSPP-1.5.4性能模式 - Perf.",
       "launch": "launch_1.15.4.sh"
-    }	
+    }
   ]
 }

--- a/Emus/PSP/default.sh
+++ b/Emus/PSP/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/PSP/launch_1.15.4.sh
+++ b/Emus/PSP/launch_1.15.4.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+source /mnt/SDCARD/System/usr/trimui/scripts/common_launcher.sh
 echo $0 $*
 progdir=`dirname "$0"`
 progdir154=$progdir/PPSSPP_1.15.4

--- a/Emus/PSP/launch_1.17.1_gl.sh
+++ b/Emus/PSP/launch_1.17.1_gl.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+source /mnt/SDCARD/System/usr/trimui/scripts/common_launcher.sh
 echo $0 $*
 progdir=`dirname "$0"`
 progdir171=$progdir/PPSSPP_1.17.1

--- a/Emus/PSP/launch_1.17.1_vulkan.sh
+++ b/Emus/PSP/launch_1.17.1_vulkan.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+source /mnt/SDCARD/System/usr/trimui/scripts/common_launcher.sh
 echo $0 $*
 progdir=`dirname "$0"`
 progdir171=$progdir/PPSSPP_1.17.1

--- a/Emus/PSPMINIS/config.json
+++ b/Emus/PSPMINIS/config.json
@@ -1,7 +1,7 @@
 {
   "label": "PSPMINIS",
   "icon": "/mnt/SDCARD/Icons/Default/Emus/PSPMINIS.png",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "background": "/mnt/SDCARD/Backgrounds/Default/PSPMINIS.png",
   "themecolor": "64A8BD",
   "iconsel": "",

--- a/Emus/PSPMINIS/default.sh
+++ b/Emus/PSPMINIS/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/SATELLAVIEW/config.json
+++ b/Emus/SATELLAVIEW/config.json
@@ -5,7 +5,7 @@
   "iconlist": "",
   "background": "/mnt/SDCARD/Backgrounds/Default/SATELLAVIEW.png",
   "themecolor": "FF0000",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/SATELLAVIEW",
   "imgpath": "../../Imgs/SATELLAVIEW",
   "useswap": 0,

--- a/Emus/SATELLAVIEW/default.sh
+++ b/Emus/SATELLAVIEW/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/SATURN/config.json
+++ b/Emus/SATURN/config.json
@@ -5,7 +5,7 @@
   "iconlist": "",
   "background": "/mnt/SDCARD/Backgrounds/Default/SATURN.png",
   "themecolor": "FFFF88",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/SATURN",
   "imgpath": "../../Imgs/SATURN",
   "useswap": 1,

--- a/Emus/SATURN/default.sh
+++ b/Emus/SATURN/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/SCUMMVM/config.json
+++ b/Emus/SCUMMVM/config.json
@@ -3,7 +3,7 @@
   "icon": "/mnt/SDCARD/Icons/Default/Emus/SCUMMVM.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/SCUMMVM.png",
   "themecolor": "00D300",
-  "launch": "scummvm-2.8.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/SCUMMVM",
   "imgpath": "../../Imgs/SCUMMVM",
   "useswap": 1,

--- a/Emus/SCUMMVM/default.sh
+++ b/Emus/SCUMMVM/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/SEGA32X/config.json
+++ b/Emus/SEGA32X/config.json
@@ -3,7 +3,7 @@
   "icon": "/mnt/SDCARD/Icons/Default/Emus/SEGA32X.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/SEGA32X.png",
   "iconsel": "",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/SEGA32X",
   "imgpath": "../../Imgs/SEGA32X",
   "useswap": 0,

--- a/Emus/SEGA32X/default.sh
+++ b/Emus/SEGA32X/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/SEGACD/config.json
+++ b/Emus/SEGACD/config.json
@@ -5,7 +5,7 @@
   "iconlist": "ic-SCD-list.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/SEGACD.png",
   "themecolor": "FFFF88",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/SEGACD",
   "imgpath": "../../Imgs/SEGACD",
   "useswap": 1,

--- a/Emus/SEGACD/default.sh
+++ b/Emus/SEGACD/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/SFC/config.json
+++ b/Emus/SFC/config.json
@@ -3,7 +3,7 @@
   "icon": "/mnt/SDCARD/Icons/Default/Emus/SFC.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/SFC.png",
   "themecolor": "00FF88",
-  "launch": "snes9x.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/SFC",
   "imgpath": "../../Imgs/SFC",
   "useswap": 0,

--- a/Emus/SFC/default.sh
+++ b/Emus/SFC/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/SFCMSU/config.json
+++ b/Emus/SFCMSU/config.json
@@ -5,7 +5,7 @@
   "iconlist": "",
   "background": "/mnt/SDCARD/Backgrounds/Default/SFCMSU.png",
   "themecolor": "FF0000",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/SFCMSU",
   "imgpath": "../../Imgs/SFCMSU",
   "useswap": 0,

--- a/Emus/SFCMSU/default.sh
+++ b/Emus/SFCMSU/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/SFX/config.json
+++ b/Emus/SFX/config.json
@@ -5,7 +5,7 @@
   "iconlist": "",
   "background": "/mnt/SDCARD/Backgrounds/Default/SFX.png",
   "themecolor": "FFFF88",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/SFX",
   "imgpath": "../../Imgs/SFX",
   "useswap": 1,

--- a/Emus/SFX/default.sh
+++ b/Emus/SFX/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/SG1000/config.json
+++ b/Emus/SG1000/config.json
@@ -3,7 +3,7 @@
   "icon": "/mnt/SDCARD/Icons/Default/Emus/SG1000.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/SG1000.png",
   "iconsel": "",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/SG1000",
   "imgpath": "../../Imgs/SG1000",
   "useswap": 0,

--- a/Emus/SG1000/default.sh
+++ b/Emus/SG1000/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/SGB/config.json
+++ b/Emus/SGB/config.json
@@ -3,7 +3,7 @@
   "icon": "/mnt/SDCARD/Icons/Default/Emus/SGB.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/SGB.png",
   "iconsel": "",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/SGB",
   "imgpath": "../../Imgs/SGB",
   "useswap": 0,

--- a/Emus/SGB/default.sh
+++ b/Emus/SGB/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/SUFAMI/config.json
+++ b/Emus/SUFAMI/config.json
@@ -5,7 +5,7 @@
   "iconlist": "",
   "background": "/mnt/SDCARD/Backgrounds/Default/SUFAMI.png",
   "themecolor": "FF0000",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/SUFAMI",
   "imgpath": "../../Imgs/SUFAMI",
   "useswap": 0,

--- a/Emus/SUFAMI/default.sh
+++ b/Emus/SUFAMI/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/SUPERVISION/config.json
+++ b/Emus/SUPERVISION/config.json
@@ -5,7 +5,7 @@
   "iconlist": "",
   "background": "/mnt/SDCARD/Backgrounds/Default/SUPERVISION.png",
   "themecolor": "FF0000",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/SUPERVISION",
   "imgpath": "../../Imgs/SUPERVISION",
   "useswap": 0,

--- a/Emus/SUPERVISION/default.sh
+++ b/Emus/SUPERVISION/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/THOMSON/config.json
+++ b/Emus/THOMSON/config.json
@@ -3,7 +3,7 @@
   "icon": "/mnt/SDCARD/Icons/Default/Emus/THOMSON.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/THOMSON.png",
   "iconsel": "",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/THOMSON",
   "imgpath": "../../Imgs/THOMSON",
   "useswap": 0,

--- a/Emus/THOMSON/default.sh
+++ b/Emus/THOMSON/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/TI83/config.json
+++ b/Emus/TI83/config.json
@@ -5,7 +5,7 @@
   "iconlist": "ic-cps1-32-n.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/TI83.png",
   "themecolor": "0000FF",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/TI83",
   "imgpath": "../../Imgs/TI83",
   "useswap": 1,

--- a/Emus/TI83/default.sh
+++ b/Emus/TI83/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/TI83/launch.sh
+++ b/Emus/TI83/launch.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+source /mnt/SDCARD/System/usr/trimui/scripts/common_launcher.sh
 RA_DIR=/mnt/SDCARD/RetroArch
 EMU_DIR=/mnt/SDCARD/Emus/TI88
 cd $RA_DIR/

--- a/Emus/TIC/config.json
+++ b/Emus/TIC/config.json
@@ -5,7 +5,7 @@
   "iconlist": "ic-TIC-list.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/TIC.png",
   "themecolor": "FFFF88",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/TIC",
   "imgpath": "../../Imgs/TIC",
   "useswap": 1,

--- a/Emus/TIC/default.sh
+++ b/Emus/TIC/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/TYRQUAKE/config.json
+++ b/Emus/TYRQUAKE/config.json
@@ -5,7 +5,7 @@
   "iconlist": "ic-C64-list.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/TYRQUAKE.png",
   "themecolor": "FFFF88",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/TYRQUAKE",
   "imgpath": "../../Imgs/TYRQUAKE",
   "useswap": 1,

--- a/Emus/TYRQUAKE/default.sh
+++ b/Emus/TYRQUAKE/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/UZEBOX/config.json
+++ b/Emus/UZEBOX/config.json
@@ -3,7 +3,7 @@
   "icon": "/mnt/SDCARD/Icons/Default/Emus/UZEBOX.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/UZEBOX.png",
   "iconsel": "",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/UZEBOX",
   "imgpath": "../../Imgs/UZEBOX",
   "useswap": 0,

--- a/Emus/UZEBOX/default.sh
+++ b/Emus/UZEBOX/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/VB/config.json
+++ b/Emus/VB/config.json
@@ -5,7 +5,7 @@
   "iconlist": "",
   "background": "/mnt/SDCARD/Backgrounds/Default/VB.png",
   "themecolor": "FFFF88",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/VB",
   "imgpath": "../../Imgs/VB",
   "useswap": 1,

--- a/Emus/VB/default.sh
+++ b/Emus/VB/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/VECTREX/config.json
+++ b/Emus/VECTREX/config.json
@@ -3,7 +3,7 @@
   "icon": "/mnt/SDCARD/Icons/Default/Emus/VECTREX.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/VECTREX.png",
   "iconsel": "",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/VECTREX",
   "imgpath": "../../Imgs/VECTREX",
   "useswap": 0,

--- a/Emus/VECTREX/default.sh
+++ b/Emus/VECTREX/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/VIC20/config.json
+++ b/Emus/VIC20/config.json
@@ -5,7 +5,7 @@
   "iconlist": "ic-X1-list.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/VIC20.png",
   "themecolor": "FFFF88",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/VIC20",
   "imgpath": "../../Imgs/VIC20",
   "useswap": 1,

--- a/Emus/VIC20/default.sh
+++ b/Emus/VIC20/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/VIDEOPAC/config.json
+++ b/Emus/VIDEOPAC/config.json
@@ -3,7 +3,7 @@
   "icon": "/mnt/SDCARD/Icons/Default/Emus/VIDEOPAC.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/VIDEOPAC.png",
   "iconsel": "",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/VIDEOPAC",
   "imgpath": "../../Imgs/VIDEOPAC",
   "useswap": 0,

--- a/Emus/VIDEOPAC/default.sh
+++ b/Emus/VIDEOPAC/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/VIDEOS/config.json
+++ b/Emus/VIDEOS/config.json
@@ -16,7 +16,7 @@
       "name": "mpv",
       "launch": "mpv.sh"
     },
-	{
+    {
       "name": "Libretro FFmpeg",
       "launch": "ffmpeg.sh"
     }

--- a/Emus/VIDEOTON/config.json
+++ b/Emus/VIDEOTON/config.json
@@ -5,7 +5,7 @@
   "iconlist": "ic-C64-list.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/VIDEOTON.png",
   "themecolor": "FFFF88",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/VIDEOTON",
   "imgpath": "../../Imgs/VIDEOTON",
   "useswap": 1,

--- a/Emus/VIDEOTON/default.sh
+++ b/Emus/VIDEOTON/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/VMAC/config.json
+++ b/Emus/VMAC/config.json
@@ -5,7 +5,7 @@
   "iconlist": "ic-C64-list.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/VMAC.png",
   "themecolor": "FFFF88",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/VMAC",
   "imgpath": "../../Imgs/VMAC",
   "useswap": 1,

--- a/Emus/VMAC/default.sh
+++ b/Emus/VMAC/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/WS/config.json
+++ b/Emus/WS/config.json
@@ -3,7 +3,7 @@
   "icon": "/mnt/SDCARD/Icons/Default/Emus/WS.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/WS.png",
   "iconsel": "",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/WS",
   "imgpath": "../../Imgs/WS",
   "useswap": 0,

--- a/Emus/WS/default.sh
+++ b/Emus/WS/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/WSC/config.json
+++ b/Emus/WSC/config.json
@@ -5,7 +5,7 @@
   "iconlist": "ic-WSC-32-n.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/WSC.png",
   "themecolor": "3C4593",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/WSC",
   "imgpath": "../../Imgs/WSC",
   "useswap": 0,

--- a/Emus/WSC/default.sh
+++ b/Emus/WSC/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/X1/config.json
+++ b/Emus/X1/config.json
@@ -5,7 +5,7 @@
   "iconlist": "ic-X1-list.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/X1.png",
   "themecolor": "FFFF88",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/X1",
   "imgpath": "../../Imgs/X1",
   "useswap": 1,

--- a/Emus/X1/default.sh
+++ b/Emus/X1/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/X68000/config.json
+++ b/Emus/X68000/config.json
@@ -3,7 +3,7 @@
   "icon": "/mnt/SDCARD/Icons/Default/Emus/X68000.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/X68000.png",
   "iconsel": "",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/X68000",
   "imgpath": "../../Imgs/X68000",
   "useswap": 0,

--- a/Emus/X68000/default.sh
+++ b/Emus/X68000/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/XRICK/config.json
+++ b/Emus/XRICK/config.json
@@ -5,7 +5,7 @@
   "iconlist": "ic-C64-list.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/XRICK.png",
   "themecolor": "FFFF88",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/XRICK",
   "imgpath": "../../Imgs/XRICK",
   "useswap": 1,

--- a/Emus/XRICK/default.sh
+++ b/Emus/XRICK/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/Emus/ZXS/config.json
+++ b/Emus/ZXS/config.json
@@ -3,7 +3,7 @@
   "icon": "/mnt/SDCARD/Icons/Default/Emus/ZXS.png",
   "background": "/mnt/SDCARD/Backgrounds/Default/ZXS.png",
   "iconsel": "",
-  "launch": "launch.sh",
+  "launch": "default.sh",
   "rompath": "../../Roms/ZXS",
   "imgpath": "../../Imgs/ZXS",
   "useswap": 0,

--- a/Emus/ZXS/default.sh
+++ b/Emus/ZXS/default.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+source /mnt/SDCARD/System/usr/trimui/scripts/load_launcher.sh

--- a/System/usr/trimui/scripts/common_launcher.sh
+++ b/System/usr/trimui/scripts/common_launcher.sh
@@ -1,5 +1,20 @@
-#!/bin/sh
+#Find the Emulator directory (first Emus/ subdirectory)
+EMU_DIR="$(echo "$0" | sed 's|\(.*Emus/[^/]*\)/.*|\1|')"
+PM_DIR="/mnt/SDCARD/Apps/PortMaster/PortMaster"
 
-source /mnt/SDCARD/System/usr/trimui/scripts/FolderOverrideFinder.sh
+export PATH="/mnt/SDCARD/System/usr/trimui/scripts/:/mnt/SDCARD/System/bin:$PM_DIR:${PATH:+:$PATH}"
+export LD_LIBRARY_PATH="/usr/trimui/lib:/mnt/SDCARD/System/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 
-/mnt/SDCARD/System/usr/trimui/scripts/ra_audio_switcher.sh
+dir=/mnt/SDCARD/System/usr/trimui/scripts
+
+if grep -q ra64.trimui "$0"; then
+    RA_DIR="/mnt/SDCARD/RetroArch"
+    export PATH=$PATH:$RA_DIR
+
+    source $dir/FolderOverrideFinder.sh
+
+    ra_audio_switcher.sh
+fi
+
+cd "$EMU_DIR"
+source $dir/save_launcher.sh

--- a/System/usr/trimui/scripts/common_launcher.sh
+++ b/System/usr/trimui/scripts/common_launcher.sh
@@ -1,5 +1,5 @@
 #Find the Emulator directory (first Emus/ subdirectory)
-EMU_DIR="$(echo "$0" | sed 's|\(.*Emus/[^/]*\)/.*|\1|')"
+EMU_DIR="$(echo "$0" | sed -E 's|\(.*Emus/[^/]*\)/.*|\1|')"
 PM_DIR="/mnt/SDCARD/Apps/PortMaster/PortMaster"
 
 export PATH="/mnt/SDCARD/System/usr/trimui/scripts/:/mnt/SDCARD/System/bin:$PM_DIR:${PATH:+:$PATH}"

--- a/System/usr/trimui/scripts/load_launcher.sh
+++ b/System/usr/trimui/scripts/load_launcher.sh
@@ -4,25 +4,31 @@ export LD_LIBRARY_PATH="/usr/trimui/lib:${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 EMU_DIR="$(dirname "$0")"
 GAME=$(basename "$@")
 
-# The preset file is only created after a first saved launcher.
 if [ -e "$EMU_DIR/presets.txt" ]; then
-	# Press L to start a game with a saved launcher.
-	button_state.sh L
-	[ $? -eq 10 ] && Launcher_name=$(grep -i "$GAME" "$EMU_DIR/presets.txt" | cut -d'=' -f2)
+	Launcher_name=$(grep -i "$GAME" "$EMU_DIR/presets.txt" | cut -d'=' -f2)
 
-	[ -z "$Launcher_name" ] && Launcher_name=$(grep -i default "$EMU_DIR/presets.txt" | cut -d'=' -f2)
-	Launcher_command=$(jq -r --arg name "$Launcher_name" \
-		'.launchlist[] | select(.name == $name) | .launch' "$EMU_DIR/config.json")
-elif jq -e ".launchlist" "$EMU_DIR/config.json" > /dev/null 2>&1; then
-# So if it not yet created, search for the first valid launcher.
-	while read launcher; do
-		Launcher_name=$(echo "$launcher" | jq -r '.name')
-		Launcher_command=$(echo "$launcher" | jq -r '.launch')
-		if [ -n "$Launcher_command" ]; then break; fi
-	done < <(jq -c '.launchlist[]' "$EMU_DIR/config.json")
-else
-  Launcher_name=Unique
-  Launcher_command="$EMU_DIR/launch.sh"
+	if [ -z "$Launcher_name" ]; then
+		Launcher_name=$(grep -i default "$EMU_DIR/presets.txt" | cut -d'=' -f2)
+	fi
+
+	if [ -n "$Launcher_name" ]; then
+		Launcher_command=$(jq -r --arg name "$Launcher_name" \
+			'.launchlist[] | select(.name == $name) | .launch' "$EMU_DIR/config.json")
+	fi
+fi
+
+if [ -z "$Launcher_name" ]; then
+	if jq -e ".launchlist" "$EMU_DIR/config.json" >/dev/null 2>&1; then
+		# So if it not yet created, search for the first valid launcher.
+		while read launcher; do
+			Launcher_name=$(echo "$launcher" | jq -r '.name')
+			Launcher_command=$(echo "$launcher" | jq -r '.launch')
+			if [ -n "$Launcher_command" ]; then break; fi
+		done < <(jq -c '.launchlist[]' "$EMU_DIR/config.json")
+	else
+		Launcher_name=Unique
+		Launcher_command="$EMU_DIR/launch.sh"
+	fi
 fi
 
 echo "load_launcher.sh : $Launcher_name dowork 0x" >>/tmp/log/messages

--- a/System/usr/trimui/scripts/load_launcher.sh
+++ b/System/usr/trimui/scripts/load_launcher.sh
@@ -4,10 +4,13 @@ export LD_LIBRARY_PATH="/usr/trimui/lib:${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 EMU_DIR="$(dirname "$0")"
 GAME=$(basename "$@")
 
+# Look for a saved preset
 if [ -e "$EMU_DIR/presets.txt" ]; then
+  # Is there a preset for the game ?
 	Launcher_name=$(grep -i "$GAME" "$EMU_DIR/presets.txt" | cut -d'=' -f2)
 
 	if [ -z "$Launcher_name" ]; then
+    # else is there a default preset ?
 		Launcher_name=$(grep -i default "$EMU_DIR/presets.txt" | cut -d'=' -f2)
 	fi
 
@@ -17,15 +20,17 @@ if [ -e "$EMU_DIR/presets.txt" ]; then
 	fi
 fi
 
+# If no preset found
 if [ -z "$Launcher_name" ]; then
+  # Look for the first valid launcher in launchlist
 	if jq -e ".launchlist" "$EMU_DIR/config.json" >/dev/null 2>&1; then
-		# So if it not yet created, search for the first valid launcher.
 		while read launcher; do
 			Launcher_name=$(echo "$launcher" | jq -r '.name')
 			Launcher_command=$(echo "$launcher" | jq -r '.launch')
 			if [ -n "$Launcher_command" ]; then break; fi
 		done < <(jq -c '.launchlist[]' "$EMU_DIR/config.json")
 	else
+    # Else use launch.sh as fallback
 		Launcher_name=Unique
 		Launcher_command="$EMU_DIR/launch.sh"
 	fi

--- a/System/usr/trimui/scripts/load_launcher.sh
+++ b/System/usr/trimui/scripts/load_launcher.sh
@@ -1,0 +1,29 @@
+export PATH="/mnt/SDCARD/System/usr/trimui/scripts/:/mnt/SDCARD/System/bin:${PATH:+:$PATH}"
+export LD_LIBRARY_PATH="/usr/trimui/lib:${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+
+EMU_DIR="$(dirname "$0")"
+GAME=$(basename "$@")
+
+# The preset file is only created after a first saved launcher.
+if [ -e "$EMU_DIR/presets.txt" ]; then
+	# Press L to start a game with a saved launcher.
+	button_state.sh L
+	[ $? -eq 10 ] && Launcher_name=$(grep -i "$GAME" "$EMU_DIR/presets.txt" | cut -d'=' -f2)
+
+	[ -z "$Launcher_name" ] && Launcher_name=$(grep -i default "$EMU_DIR/presets.txt" | cut -d'=' -f2)
+	Launcher_command=$(jq -r --arg name "$Launcher_name" \
+		'.launchlist[] | select(.name == $name) | .launch' "$EMU_DIR/config.json")
+elif jq -e ".launchlist" "$EMU_DIR/config.json" > /dev/null 2>&1; then
+# So if it not yet created, search for the first valid launcher.
+	while read launcher; do
+		Launcher_name=$(echo "$launcher" | jq -r '.name')
+		Launcher_command=$(echo "$launcher" | jq -r '.launch')
+		if [ -n "$Launcher_command" ]; then break; fi
+	done < <(jq -c '.launchlist[]' "$EMU_DIR/config.json")
+else
+  Launcher_name=Unique
+  Launcher_command="$EMU_DIR/launch.sh"
+fi
+
+echo "load_launcher.sh : $Launcher_name dowork 0x" >>/tmp/log/messages
+"$EMU_DIR/$Launcher_command" "$@"

--- a/System/usr/trimui/scripts/save_launcher.sh
+++ b/System/usr/trimui/scripts/save_launcher.sh
@@ -1,0 +1,22 @@
+GAME=$(basename "$1")
+
+# Save launcher as default for the game
+button_state.sh L
+if [ $? -eq 10 ]; then
+	Launcher_name=$(grep "dowork 0x" "/tmp/log/messages" | tail -n 1 | sed -e 's/.*: \(.*\) dowork 0x.*/\1/')
+	if [ -e "$EMU_DIR/presets.txt" ]; then
+		sed -i "/$GAME/d" "$EMU_DIR/presets.txt"
+	fi
+	echo "$GAME=$Launcher_name" >>"$EMU_DIR/presets.txt"
+else
+	# Save launcher as default one
+	button_state.sh R
+	if [ $? -eq 10 ]; then
+		Launcher_name=$(grep "dowork 0x" "/tmp/log/messages" | tail -n 1 | sed -e 's/.*: \(.*\) dowork 0x.*/\1/')
+		if [ -e "$EMU_DIR/presets.txt" ]; then
+			sed -i "s/^default=.*$/default=$Launcher_name/" "$EMU_DIR/presets.txt"
+		else
+			echo "default=$Launcher_name" >"$EMU_DIR/presets.txt"
+		fi
+	fi
+fi

--- a/System/usr/trimui/scripts/save_launcher.sh
+++ b/System/usr/trimui/scripts/save_launcher.sh
@@ -1,22 +1,24 @@
 GAME=$(basename "$1")
 
-# Save launcher as default for the game
-button_state.sh L
-if [ $? -eq 10 ]; then
-	Launcher_name=$(grep "dowork 0x" "/tmp/log/messages" | tail -n 1 | sed -e 's/.*: \(.*\) dowork 0x.*/\1/')
-	sed -i "/^$GAME/d" presets.txt
-	echo "$GAME=$Launcher_name" >>presets.txt
-else
+save_launcher() {
+	[ -z "$1" ] && set default
 
-	# Save launcher as default one
-	button_state.sh R
-	if [ $? -eq 10 ]; then
-		Launcher_name=$(grep "dowork 0x" "/tmp/log/messages" | tail -n 1 | sed -e 's/.*: \(.*\) dowork 0x.*/\1/')
-		if [ ! -f presets.txt ]; then
-			touch presets.txt
-		else
-			sed -i "/^default=/d" presets.txt
-		fi
+	Launcher_name=$(grep "dowork 0x" "/tmp/log/messages" | tail -n 1 | sed -e 's/.*: \(.*\) dowork 0x.*/\1/')
+
+	if [ ! -f presets.txt ]; then
+		echo "$1=$Launcher_name" >presets.txt
+	elif grep -q "^$1=" presets.txt &>/dev/null; then
+		sed -i "s/^$1=.*/$1=$Launcher_name/" presets.txt
+	elif [ "$1" = default ]; then
 		sed -i "1idefault=$Launcher_name" presets.txt
+	else
+		echo "$1=$Launcher_name" >>presets.txt
 	fi
-fi
+}
+
+button_state.sh L
+[ $? -eq 10 ] && save_launcher "$GAME"
+
+# Save launcher as default one
+button_state.sh R
+[ $? -eq 10 ] && save_launcher

--- a/System/usr/trimui/scripts/save_launcher.sh
+++ b/System/usr/trimui/scripts/save_launcher.sh
@@ -4,19 +4,19 @@ GAME=$(basename "$1")
 button_state.sh L
 if [ $? -eq 10 ]; then
 	Launcher_name=$(grep "dowork 0x" "/tmp/log/messages" | tail -n 1 | sed -e 's/.*: \(.*\) dowork 0x.*/\1/')
-	if [ -e "$EMU_DIR/presets.txt" ]; then
-		sed -i "/$GAME/d" "$EMU_DIR/presets.txt"
-	fi
-	echo "$GAME=$Launcher_name" >>"$EMU_DIR/presets.txt"
+	sed -i "/^$GAME/d" presets.txt
+	echo "$GAME=$Launcher_name" >>presets.txt
 else
+
 	# Save launcher as default one
 	button_state.sh R
 	if [ $? -eq 10 ]; then
 		Launcher_name=$(grep "dowork 0x" "/tmp/log/messages" | tail -n 1 | sed -e 's/.*: \(.*\) dowork 0x.*/\1/')
-		if [ -e "$EMU_DIR/presets.txt" ]; then
-			sed -i "s/^default=.*$/default=$Launcher_name/" "$EMU_DIR/presets.txt"
+		if [ ! -f presets.txt ]; then
+			touch presets.txt
 		else
-			echo "default=$Launcher_name" >"$EMU_DIR/presets.txt"
+			sed -i "/^default=/d" presets.txt
 		fi
+		sed -i "1idefault=$Launcher_name" presets.txt
 	fi
 fi


### PR DESCRIPTION
Allow to save a preset launcher for each game
Also allow to change a system default launcher

It is implemented for each system but systems with only
one launcher will not notice a difference until they add
a launchlist in the config.json
Default launcher are choose from presets.txt if it exist else
it use the first valid launcher in config.json 's launchlist.
As fallback when there is no launchlist, it just call launch.sh.

When a presets.txt exist, if the user press L key while starting a
game, it will look for a game specific launcher, else it will just
start the customized system's launcher.

You can save a launcher in presets.txt by using the X key and holding
either L key to save for the game or R to save as system's default.
