### PR TITLE
[Fix] Missing new gptokeyb2 dependency for mgba standalone

### DIFF
--- a/Emus/GBA/mgba_standalone.sh
+++ b/Emus/GBA/mgba_standalone.sh
@@ -2,7 +2,7 @@
 source /mnt/SDCARD/System/usr/trimui/scripts/common_launcher.sh
 cpufreq.sh ondemand 2 6
 
-export LD_LIBRARY_PATH="/mnt/SDCARD/System/lib:$EMU_DIR/lib:/usr/lib:$LD_LIBRARY_PATH"
+export LD_LIBRARY_PATH="$PM_DIR:/mnt/SDCARD/System/lib:$EMU_DIR/lib:/usr/lib:$LD_LIBRARY_PATH"
 export XDG_CONFIG_HOME="$EMU_DIR/.config"
 
 /mnt/SDCARD/Apps/PortMaster/PortMaster/gptokeyb2 "mgba" -k "mgba" -c "/mnt/SDCARD/Emus/GBA/.config/mgba/mgba.gptk" &


### PR DESCRIPTION
gptokeyb2 new depend on a libinterpose which is in PortMaster directory.