### PR TITLE
[Fix] Typo in PSP launchers that inverted normal and performance modes

### DIFF
--- a/Emus/PSP/ppsspp_1.15.4.sh
+++ b/Emus/PSP/ppsspp_1.15.4.sh
@@ -6,7 +6,7 @@ export LD_LIBRARY_PATH="/usr/trimui/lib" # "/mnt/SDCARD/System/lib" = segfault
 cd PPSSPP_1.15.4
 
 performance=$(grep -i "dowork 0x" "/tmp/log/messages" | tail -n 1 | grep -i "Perf.")
-if [ -z "$performance" ]; then
+if [ -n "$performance" ]; then
     cpufreq.sh ondemand 3 8
 else
     cpufreq.sh ondemand 3 6

--- a/Emus/PSP/ppsspp_1.17.1_gl.sh
+++ b/Emus/PSP/ppsspp_1.17.1_gl.sh
@@ -5,7 +5,7 @@ source /mnt/SDCARD/System/usr/trimui/scripts/common_launcher.sh
 cd PPSSPP_1.17.1
 
 performance=$(grep -i "dowork 0x" "/tmp/log/messages" | tail -n 1 | grep -i "Perf.") # We detect the performance mode from the label which have been selected in launcher menu
-if [ -z "$performance" ]; then
+if [ -n "$performance" ]; then
     cpufreq.sh ondemand 3 8
 else
     cpufreq.sh ondemand 3 6

--- a/Emus/PSP/ppsspp_1.17.1_vulkan.sh
+++ b/Emus/PSP/ppsspp_1.17.1_vulkan.sh
@@ -5,7 +5,7 @@ source /mnt/SDCARD/System/usr/trimui/scripts/common_launcher.sh
 cd PPSSPP_1.17.1
 
 performance=$(grep -i "dowork 0x" "/tmp/log/messages" | tail -n 1 | grep -i "Perf.") # We detect the performance mode from the label which have been selected in launcher menu
-if [ -z "$performance" ]; then
+if [ -n "$performance" ]; then
     cpufreq.sh ondemand 3 8
 else
     cpufreq.sh ondemand 3 6


### PR DESCRIPTION
This pull request fix a typo introduced in 1.3.0 that invert normal and performance modes when selecting a PSP emulator.