### PR TITLE
Add cannonball extlist

### DIFF
--- a/Emus/CANNONBALL/config.json
+++ b/Emus/CANNONBALL/config.json
@@ -10,5 +10,6 @@
   "imgpath": "../../Imgs/CANNONBALL",
   "useswap": 1,
   "shortname": 0,
-  "hidebios": 1
+  "hidebios": 1,
+  "extlist": "game|88"
 }


### PR DESCRIPTION
Greatly reduce clutter in the launcher since Cannonball require more than ~40 files but only two actually launch the game.

Content that can be loaded by the Cannonball core have the following file extensions: .game, .88 https://docs.libretro.com/library/cannonball/