### PR TITLE
Use Pico-8 Cartiges as their own Images

### DIFF
--- a/System/starts/°customization.sh
+++ b/System/starts/°customization.sh
@@ -120,6 +120,9 @@ if [ "$version" != "$FW_patched_version" ]; then
 	# Displaying only Emulators with roms
 	/mnt/SDCARD/Apps/EmuCleaner/launch.sh -s
 
+	# Use Pico-8 Cartiges as their own Images 
+ 	mount -o bind /mnt/SDCARD/Roms/PICO /mnt/SDCARD/Imgs/PICO
+
 	################ Flash boot logo ################
 	if [ "$CrossMix_Update" = "0" ]; then
 		CrossMixFWfile="/mnt/SDCARD/trimui/firmwares/MinFwVersion.txt"


### PR DESCRIPTION
Pico-8 Cartiges are png files, with art on them, with the game data inside. I added a line to customization to make the PICO Roms folder act also as its Imgs folder. There's probably a better way to do this, but for now this is working for me.

`mount -o bind /mnt/SDCARD/Roms/PICO /mnt/SDCARD/Imgs/PICO`

Example:
[This png file](https://www.lexaloffle.com/bbs/cposts/so/solitomb-3.p8.png) is the actual rom file running [here](https://www.lexaloffle.com/bbs/?pid=solitomb-3).