### PR TITLE
Fix TSP1.1 recognition

### DIFF
--- a/System/starts/_FirmwareCheck.sh
+++ b/System/starts/_FirmwareCheck.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
 if ! read -r current_device < /etc/trimui_device.txt; then
-    display=$(fbset | grep ^mode | cut -d "\"" -f 2)
-    if [ "$display" = "1280x720-64" ]; then
+    hwserial=$(awk '/^hwserial/{print $NF}' /proc/cpuinfo )
+    if [ "${hwserial::6}" = "TG5040" ]; then
         current_device="tsp"
     else
         current_device="brick"


### PR DESCRIPTION
TSP's firmware 1.10 changed display refresh rate as using display as device detection was no more a good solution.