### PR TITLE
Scraper: better normalize of game title

### DIFF
--- a/System/usr/trimui/scripts/scraper/scrap_screenscraper.sh
+++ b/System/usr/trimui/scripts/scraper/scrap_screenscraper.sh
@@ -373,14 +373,12 @@ for file in $(eval "find /mnt/SDCARD/Roms/$CurrentSystem -maxdepth 2 -type f \
     echo $romNameNoExtension
 
     romNameTrimmed="${romNameNoExtension/".nkit"/}"
-    romNameTrimmed="${romNameTrimmed//"!"/}"
-    romNameTrimmed="${romNameTrimmed//"&"/}"
-    romNameTrimmed="${romNameTrimmed/"Disc "/}"
-    romNameTrimmed="${romNameTrimmed/"Rev "/}"
-    romNameTrimmed="$(echo "$romNameTrimmed" | sed -e 's/ ([^()]*)//g' -e 's/ \[[^]]*\]//g')"
-    romNameTrimmed="${romNameTrimmed//" - "/"%20"}"
-    romNameTrimmed="${romNameTrimmed/"-"/"%20"}"
-    romNameTrimmed="${romNameTrimmed//" "/"%20"}"
+    romNameTrimmed="$(echo "$romNameTrimmed" | sed \
+       -e 's/\(!\|&\|Disc\|Rev\)//g' \
+       -e 's/([^()]*)//g' \
+       -e 's/\[[^]]*\]//g' \
+       -e 's/[_ -]*$//' \
+       -e 's/[_ -]/%20/'g)"
 
     #echo $romNameTrimmed # for debugging
 

--- a/System/usr/trimui/scripts/scraper/scrap_screenscraper.sh
+++ b/System/usr/trimui/scripts/scraper/scrap_screenscraper.sh
@@ -373,12 +373,11 @@ for file in $(eval "find /mnt/SDCARD/Roms/$CurrentSystem -maxdepth 2 -type f \
     echo $romNameNoExtension
 
     romNameTrimmed="${romNameNoExtension/".nkit"/}"
-    romNameTrimmed="$(echo "$romNameTrimmed" | sed \
-       -e 's/\(!\|&\|Disc\|Rev\|CD[0-9]\)//g' \
-       -e 's/([^()]*)//g' \
-       -e 's/\[[^]]*\]//g' \
-       -e 's/[_ -]*$//' \
-       -e 's/[_ -]/%20/'g)"
+    romNameTrimmed="$(echo "$title" | sed -E \
+       	-e 's/(!|&|Disc|Rev|CD[0-9])//g' \
+        -e 's| *[[(].*||' \
+        -e 's/(\s|-|_)+$//' \
+        -e 's|[_ ]|%20|g')"
 
     #echo $romNameTrimmed # for debugging
 

--- a/System/usr/trimui/scripts/scraper/scrap_screenscraper.sh
+++ b/System/usr/trimui/scripts/scraper/scrap_screenscraper.sh
@@ -374,7 +374,7 @@ for file in $(eval "find /mnt/SDCARD/Roms/$CurrentSystem -maxdepth 2 -type f \
 
     romNameTrimmed="${romNameNoExtension/".nkit"/}"
     romNameTrimmed="$(echo "$romNameTrimmed" | sed \
-       -e 's/\(!\|&\|Disc\|Rev\)//g' \
+       -e 's/\(!\|&\|Disc\|Rev\|CD[0-9]\)//g' \
        -e 's/([^()]*)//g' \
        -e 's/\[[^]]*\]//g' \
        -e 's/[_ -]*$//' \


### PR DESCRIPTION
@cizia64 hello and thank you for your **great** work!

Downloading roms from the net, many of them contain a bunch of unnecessary meta data, usually in round  or square brackets. Previously parentheses were not taken into account, although they are quite common (or it is in my collection of roms so).

Anyway, hopefully this will improve the search for the game cover art in the database, because that's basically the only way to get it, due to the 100MB checksum limit of roms (as alternative way, **but why?**).  Many PS/PSP roms take much more than 100MB...

Example of how you can test my PR:
I shortened a bit of existing code and combined sed's into one command for more consistency.

```sh


titles=("TEKKEN 3 Plus_[SLPS-01300] [FireCross+brill-fix] Rev" \
    "Parasite Eve 3 - The 3rd Birthday [RUS] [TAGTeam]" \
    "Alex Kidd in Miracle World (UEB) (V1.1) [!]" \
    "Alone in the Dark 1 (Rus)" \
    "Circus Lido (J)[T+Rus0.7_Cool-Spot]" \
    "Lode Runner - Ushina Wareta Meikyuu (Japan) [T+Eng0.99_Dave Shadoff (09.03.2002)]" \
    "Metal_Stoker_(Japan)"
    "Ape Escape [SLES-01564] (eu) [FireCross]" \
    "Resident Evil Code - Veronica CD1"
)

for title in "${titles[@]}"; do
    trimmedTitle="$(echo "$title" | sed -E \
       	-e 's/(!|&|Disc|Rev|CD[0-9])//g' \
        -e 's| *[[(].*||' \
        -e 's/(\s|-|_)+$//' \
        -e 's|[_ ]|%20|g')"
   echo "$title -> $trimmedTitle"
done
```

```
TEKKEN 3 Plus_[SLPS-01300] [FireCross+brill-fix] Rev -> TEKKEN 3 Plus
Parasite Eve 3 - The 3rd Birthday [RUS] [TAGTeam] -> Parasite Eve 3 - The 3rd Birthday
Alex Kidd in Miracle World (UEB) (V1.1) [!] -> Alex Kidd in Miracle World
Alone in the Dark 1 (Rus) -> Alone in the Dark 1
Circus Lido (J)[T+Rus0.7_Cool-Spot] -> Circus Lido
Lode Runner - Ushina Wareta Meikyuu (Japan) [T+Eng0.99_Dave Shadoff (09.03.2002)] -> Lode Runner - Ushina Wareta Meikyuu
Metal_Stoker_(Japan) -> Metal Stoker
Ape Escape [SLES-01564] (eu) [FireCross] -> Ape Escape
Resident Evil Code - Veronica CD1 -> Resident Evil Code - Veronica
```

I know that instead of a hyphen with spaces around it is now an extra whitespace, but as I found out, it doesn't affect on futher the search.

