### PR TITLE
Refactor kill_apps and cmd_to_run_killer scripts

### DIFF
--- a/System/usr/trimui/bin/kill_apps.sh
+++ b/System/usr/trimui/bin/kill_apps.sh
@@ -1,99 +1,204 @@
 #!/bin/sh
 
-#pid=`ps | grep cmd_to_run | grep -v grep | sed 's/[ ]\+/ /g' | cut -d' ' -f1`
+SELF_PID=$$
 
-/mnt/SDCARD/System/usr/trimui/scripts/button_state.sh MENU
-exit_code=$?
-if [ $exit_code -eq 10 ]; then # we don't resume if menu is pressed during boot
-   echo "=== Button MENU pressed ==="
-   /mnt/SDCARD/System/usr/trimui/scripts/cmd_to_run_killer.sh &
-   # Short Vibration
-   echo -n 1 >/sys/class/gpio/gpio227/value
-   sleep 0.1
-   echo -n 0 >/sys/class/gpio/gpio227/value
-   sleep 0.2
-   # 3 fast red blinking
-   echo 1 >/sys/class/led_anim/effect_enable
-   echo "FF0000" >/sys/class/led_anim/effect_rgb_hex_lr
-   echo 3 >/sys/class/led_anim/effect_cycles_lr
-   echo 50 >/sys/class/led_anim/effect_duration_lr
-   echo 5 >/sys/class/led_anim/effect_lr
-   exit
+# Checks if there is another instance of kill_apps.sh running
+if pgrep -f "kill_apps.sh" | grep -v "^$SELF_PID$" > /dev/null; then
+    echo "Une autre instance de kill_apps.sh est déjà en cours." >&2
+    exit 1
 fi
+
+# Configuration
+SCRIPTS_DIR="/mnt/SDCARD/System/usr/trimui/scripts"
+SYSTEM_DIR="/mnt/SDCARD/System"
+TRIMUI_DIR="/mnt/SDCARD/trimui"
+
+# Logging function
+log_message() {
+    echo "$(date '+%H:%M:%S') [kill_apps]: $1"
+}
+
+# Hardware feedback functions
+vibrate_short() {
+    echo -n 1 >/sys/class/gpio/gpio227/value
+    sleep 0.1
+    echo -n 0 >/sys/class/gpio/gpio227/value
+}
+
+set_led_animation() {
+    local color=$1
+    local cycles=$2
+    local duration=$3
+    local effect=${4:-5}
+    
+    
+    if [ ! -w "/sys/class/led_anim/effect_enable" ]; then
+        log_message "Warning: Cannot access LED animation"
+        chmod a+w /sys/class/led_anim/*
+    fi
+    
+    echo 1 >/sys/class/led_anim/effect_enable
+    echo "$color" >/sys/class/led_anim/effect_rgb_hex_lr 2>/dev/null
+    echo "$cycles" >/sys/class/led_anim/effect_cycles_lr 2>/dev/null
+    echo "$duration" >/sys/class/led_anim/effect_duration_lr 2>/dev/null
+    echo "$effect" >/sys/class/led_anim/effect_lr 2>/dev/null
+    
+}
 
 set_led_color() {
-   r=$1
-   g=$2
-   b=$3
-   valstr=$(printf "%02X%02X%02X" $r $g $b)
-   echo "$valstr $valstr $valstr $valstr $valstr $valstr $valstr $valstr $valstr $valstr $valstr $valstr $valstr $valstr $valstr $valstr " \
-      "$valstr $valstr $valstr $valstr $valstr $valstr $valstr" >/sys/class/led_anim/frame_hex
+    local r=$1
+    local g=$2
+    local b=$3
+    
+    
+    if [ ! -w "/sys/class/led_anim/frame_hex" ]; then
+        log_message "Warning: Cannot access LED frame"
+        chmod a+w /sys/class/led_anim/*
+    fi
+    
+    local valstr=$(printf "%02X%02X%02X" $r $g $b)
+    echo "$valstr $valstr $valstr $valstr $valstr $valstr $valstr $valstr $valstr $valstr $valstr $valstr $valstr $valstr $valstr $valstr " \
+    "$valstr $valstr $valstr $valstr $valstr $valstr $valstr" >/sys/class/led_anim/frame_hex
+    
+    # local valstr=$(printf "%02X%02X%02X" $r $g $b)
+    # yes "$valstr" | head -n 24 | tr '\n' ' ' | sed 's/ *$//' > /sys/class/led_anim/frame_hex
 }
-set_led_color 255 255 0 # Yellow
 
-# Short Vibration
-echo -n 1 >/sys/class/gpio/gpio227/value
-sleep 0.1
-echo -n 0 >/sys/class/gpio/gpio227/value
-sleep 0.2
+# Check if a file exists and is executable
+check_executable() {
+    local file=$1
+    if [ ! -f "$file" ]; then
+        log_message "Warning: $file not found"
+        return 1
+    fi
+    if [ ! -x "$file" ]; then
+        log_message "Warning: $file not executable"
+        return 1
+    fi
+    return 0
+}
 
-Current_Theme=$(/usr/trimui/bin/systemval theme)
-Shutdown_Screen="$Current_Theme/skin/shutdown.png"
-if [ ! -f "$Shutdown_Screen" ]; then
-   if [ -f "$Current_Theme/skin/bg.png" ]; then
-      Shutdown_Screen="$Current_Theme/skin/bg.png"
-   else
-      Shutdown_Screen="/mnt/SDCARD/trimui/res/crossmix-os/bg-info.png"
-   fi
-   Shutdown_Text="Shutting down..."
+log_message "Starting kill_apps.sh"
+
+
+if pgrep -f "drastic" > /dev/null; then
+    sigkill_countdown=10
+    log_message "Drastic detected -> Sigkill countdown = ${sigkill_countdown}s"
+fi
+
+# Check button state
+"$SCRIPTS_DIR/button_state.sh" MENU
+exit_code=$?
+if [ $exit_code -eq 10 ]; then # No shutdown and force current app to exit.
+    log_message "MENU button pressed - kill current app."
+    
+    
+    # Hardware feedback
+    vibrate_short &
+    
+    # On screen feedback
+    /usr/trimui/osd/show_default_msg_short.sh "Force App Exit" &
+    
+    # Check if smartledd is running before killing it
+    if pgrep -f smartledd >/dev/null; then
+        SMARTLEDD_WAS_RUNNING=1
+        pkill -9 smartledd
+    else
+        SMARTLEDD_WAS_RUNNING=0
+    fi
+    # Led feedback
+    set_led_animation "FF0000" 5 50 5 & # 3 fast red blinking
+    
+    # Execute cmd_to_run_killer in background for immediate response
+    if check_executable "$SCRIPTS_DIR/cmd_to_run_killer.sh"; then
+        "$SCRIPTS_DIR/cmd_to_run_killer.sh" $sigkill_countdown
+    fi
+    
+    if [ "$SMARTLEDD_WAS_RUNNING" -eq 1 ]; then
+        "/mnt/SDCARD/Apps/LedControl.pak/smartledd" &
+    fi
+    
+    log_message "Force exit app completed"
+    sync
+    exit 0
+fi
+
+# Normal shutdown sequence
+log_message "Starting normal shutdown sequence"
+
+# Set yellow LED to indicate shutdown in progress
+set_led_color 255 255 0 &
+vibrate_short &
+
+# Prepare shutdown screen
+log_message "Preparing shutdown screen"
+Current_Theme=""
+if command -v systemval >/dev/null 2>&1; then
+    Current_Theme=$(/usr/trimui/bin/systemval theme 2>/dev/null)
+fi
+
+Shutdown_Screen=""
+Shutdown_Text="Shutting down..."
+
+if [ -n "$Current_Theme" ] && [ -f "$Current_Theme/skin/shutdown.png" ]; then
+    Shutdown_Screen="$Current_Theme/skin/shutdown.png"
+    Shutdown_Text=" "
+    log_message "Using theme shutdown screen"
+    elif [ -n "$Current_Theme" ] && [ -f "$Current_Theme/skin/bg.png" ]; then
+    Shutdown_Screen="$Current_Theme/skin/bg.png"
+    log_message "Using theme background"
+    elif [ -f "$TRIMUI_DIR/res/crossmix-os/bg-info.png" ]; then
+    Shutdown_Screen="$TRIMUI_DIR/res/crossmix-os/bg-info.png"
+    log_message "Using default background"
 else
-   Shutdown_Text=" "
+    log_message "Warning: No shutdown screen found"
 fi
 
-/mnt/SDCARD/System/usr/trimui/scripts/infoscreen.sh -i "$Shutdown_Screen" -m "$Shutdown_Text" -fs 100
-
-echo 1 >/sys/class/led_anim/effect_enable
-echo "FF0000" >/sys/class/led_anim/effect_rgb_hex_lr
-echo 10 >/sys/class/led_anim/effect_cycles_lr
-echo 500 >/sys/class/led_anim/effect_duration_lr
-echo 1 >/sys/class/led_anim/effect_lr
-
-cp /tmp/cmd_to_run.sh /mnt/SDCARD/trimui/app/
-sync
-
-pkill -9 preload.sh # avoid to remove /mnt/SDCARD/trimui/app/cmd_to_run.sh when we shutdown directly from a resume
-pkill -9 runtrimui.sh
-
-pid=$1
-ppid=$pid
-
-echo "Initial pid: $pid"
-
-# Loop to find the last descendant process
-while [ -n "$pid" ]; do
-   ppid=$pid
-   pid=$(pgrep -P $ppid)
-done
-
-# Kill the last descendant process if it exists
-if [ -n "$ppid" ]; then
-   echo "Killing process $ppid"
-   kill $ppid
+# Display shutdown screen
+if [ -n "$Shutdown_Screen" ] && check_executable "$SCRIPTS_DIR/infoscreen.sh"; then
+    "$SCRIPTS_DIR/infoscreen.sh" -i "$Shutdown_Screen" -m "$Shutdown_Text" -fs 100 -t 1 &
+    log_message "Shutdown screen displayed"
+else
+    log_message "Cannot display shutdown screen"
 fi
 
-# Wait while the process identified by ppid still exists
-while kill -0 $ppid 2>/dev/null; do
-   echo "Waiting for process $ppid to exit..."
-   wait $ppid 2>/dev/null
-done
+# Red LED animation during shutdown
+set_led_animation "FF0000" 10 500 1 &
 
-echo "Process $ppid has exited."
+# Backup current script
+log_message "Backing up cmd_to_run.sh"
+if [ -f "/tmp/cmd_to_run.sh" ]; then
+    cp /tmp/cmd_to_run.sh "$TRIMUI_DIR/app/" 2>/dev/null || log_message "Warning: Could not backup cmd_to_run.sh"
+fi
+sync
 
-aplay /mnt/SDCARD/trimui/res/sound/PowerOff.wav -d 1
+# Kill background processes
+log_message "Stopping background processes"
+pkill -9 preload.sh 2>/dev/null  # avoid removing cmd_to_run.sh during direct shutdown from resume
+pkill -9 runtrimui.sh 2>/dev/null
+
+# Execute cmd_to_run_killer for clean process termination
+log_message "Executing cmd_to_run_killer $sigkill_countdown for process cleanup"
+if check_executable "$SCRIPTS_DIR/cmd_to_run_killer.sh"; then
+    "$SCRIPTS_DIR/cmd_to_run_killer.sh" $sigkill_countdown
+    log_message "Process cleanup completed"
+else
+    log_message "Warning: cmd_to_run_killer.sh not available - some processes may remain"
+fi
+
+# Play shutdown sound
+aplay "$TRIMUI_DIR/res/sound/PowerOff.wav" -d 1
 
 sync
-/mnt/SDCARD/System/bin/shutdown
+
+# Execute system shutdown
+if check_executable "$SYSTEM_DIR/bin/shutdown"; then
+    log_message "Executing system shutdown"
+    "$SYSTEM_DIR/bin/shutdown"
+else
+    log_message "Warning: system shutdown not available"
+fi
 
 sleep 8
-/mnt/SDCARD/System/usr/trimui/scripts/cmd_to_run_killer.sh
-poweroff &
+log_message "Initiating fallback poweroff"
+poweroff

--- a/System/usr/trimui/scripts/cmd_to_run_killer.sh
+++ b/System/usr/trimui/scripts/cmd_to_run_killer.sh
@@ -1,26 +1,96 @@
 #!/bin/sh
 
-find_children() {
-    local parent_pid=$1
-    local children=$(ps -e -o pid,ppid | awk -v pid="$parent_pid" '$2 == pid { print $1 }')
+# Usage: ./kill_tree.sh <timeout_seconds>
+# Example: ./kill_tree.sh 5
 
-    for child_pid in $children; do
-        echo "$child_pid"
-        find_children "$child_pid"
+TIMEOUT="${1:-3}"         # Seconds before escalating to SIGKILL (default 3s)
+CHECK_INTERVAL=0.2        # Polling interval
+KILL_LIST=""
+
+# Recursively collect child PIDs in post-order (children first, parent last)
+collect_kill_list() {
+    local pid=$1
+    local children=$(ps -e -o pid= -o ppid= | awk -v p="$pid" '$2 == p { print $1 }')
+    
+    for child in $children; do
+        collect_kill_list "$child"
     done
-	
-	kill $child_pid
-	sleep 3
-	if kill -0 "$PID" 2>/dev/null; then
-	kill -9 $child_pid
-	fi
+    
+    KILL_LIST="$KILL_LIST $pid"
 }
 
+# Attempt clean shutdown of RetroArch if it's running (ra64.trimui)
+try_clean_retroarch_exit() {
+    local ra_pid
+    ra_pid=$(pgrep -f ra64.trimui)
+    
+    if [ -n "$ra_pid" ]; then
+        
+        echo "Detected RetroArch (PID $ra_pid), attempting clean shutdown..."
+        echo -n "QUIT" | /mnt/SDCARD/System/bin/netcat -u -w1 127.0.0.1 55355
+        echo -n "QUIT" | /mnt/SDCARD/System/bin/netcat -u -w1 127.0.0.1 55355
+        
+        sleep 0.5
+        # If the TrimUI Game Menu is detected, we exit it to allow RetroArch to close properly
+        state_code=$(sed -n 's/^State:[ \t]*\([A-Z]\).*/\1/p' /proc/"$ra_pid"/status)
+        if [ "$state_code" = "S" ]; then
+            echo "TrimUI ingame menu detected"
+            /mnt/SDCARD/System/bin/sendkey /dev/input/event3 B 2
+            sleep 3
+        fi
+        
+        elapsed=0
+        while kill -0 "$ra_pid" 2>/dev/null; do
+            sleep "$CHECK_INTERVAL"
+            elapsed=$(echo "$elapsed + $CHECK_INTERVAL" | bc)
+            if [ "$(echo "$elapsed >= $TIMEOUT" | bc)" -eq 1 ]; then
+                echo "RetroArch still running after $TIMEOUT s, sending SIGKILL"
+                kill -9 "$ra_pid"
+                break
+            fi
+        done
+        
+        if ! kill -0 "$ra_pid" 2>/dev/null; then
+            echo "RetroArch terminated cleanly."
+        fi
+    fi
+}
 
+# Try to terminate a PID, escalate to SIGKILL if needed
+terminate_pid() {
+    local pid=$1
+    kill "$pid"
+    echo "sigterm sent to $pid"
+    
+    elapsed=0
+    while kill -0 "$pid" 2>/dev/null; do
+        sleep "$CHECK_INTERVAL"
+        elapsed=$(echo "$elapsed + $CHECK_INTERVAL" | bc)
+        if [ "$(echo "$elapsed >= $TIMEOUT" | bc)" -eq 1 ]; then
+            echo "Process $pid still alive after $TIMEOUT s, sending SIGKILL"
+            kill -9 "$pid"
+            break
+        fi
+    done
+}
+
+# Try to shut down RetroArch cleanly if running
+try_clean_retroarch_exit
+
+# Find the parent process
 PARENT_PID=$(pgrep -f "cmd_to_run.sh")
 if [ -n "$PARENT_PID" ]; then
-    echo "Processus parent : $PARENT_PID"
-    find_children "$PARENT_PID"
+    echo "Found parent process: $PARENT_PID"
+    
+    collect_kill_list "$PARENT_PID"
+    
+    for pid in $KILL_LIST; do
+        echo "Terminating $pid"
+        terminate_pid "$pid"
+    done
 else
     echo "No matching process found."
 fi
+
+
+


### PR DESCRIPTION
Major refactor of kill_apps.sh and cmd_to_run_killer.sh for improved reliability.

- Kill the last child of the cmd_to_run.sh first
- Use UDP network commands to exit
- more graceful exit for drastic (wait 10 seconds before sigkill)
- added OSD message feedback
- improved led effects management (manage file rights and the new smartledd daemon)
- add more debug info
- wait app really exited before playing "shutdown" sound