### PR TITLE
PPSSPP mute fix

### DIFF
--- a/Emus/PSP/ppsspp_1.17.1_gl.sh
+++ b/Emus/PSP/ppsspp_1.17.1_gl.sh
@@ -17,7 +17,14 @@ fi
 
 # We set the Backend to OpenGL
 config_file="/mnt/SDCARD/Emus/PSP/PPSSPP_1.17.1/.config/ppsspp/PSP/SYSTEM/ppsspp.ini"
-sed -i '/^\[Graphics\]$/,/^\[/ s/GraphicsBackend = .*/GraphicsBackend = 0/' "$config_file"
+sed -i '
+/^\[Graphics\]$/,/^\[/ {
+    s/^GraphicsBackend = .*/GraphicsBackend = 0/
+}
+/^\[Sound\]$/,/^\[/ {
+    s/^GlobalVolume = \(10\|[0-9]\)$/GlobalVolume = 10/
+}
+' "$config_file"
 
 #export SDL_AUDIODRIVER=dsp   //disable 20231031 for sound suspend issue
 HOME=$PWD ./PPSSPPSDL_gl "$*"

--- a/Emus/PSP/ppsspp_1.17.1_vulkan.sh
+++ b/Emus/PSP/ppsspp_1.17.1_vulkan.sh
@@ -17,7 +17,14 @@ fi
 
 # We set the Backend to Vulkan
 config_file="/mnt/SDCARD/Emus/PSP/PPSSPP_1.17.1/.config/ppsspp/PSP/SYSTEM/ppsspp.ini"
-sed -i '/^\[Graphics\]$/,/^\[/ s/GraphicsBackend = .*/GraphicsBackend = 3/' "$config_file"
+sed -i '
+/^\[Graphics\]$/,/^\[/ {
+    s/^GraphicsBackend = .*/GraphicsBackend = 3/
+}
+/^\[Sound\]$/,/^\[/ {
+    s/^GlobalVolume = \(10\|[0-9]\)$/GlobalVolume = 10/
+}
+' "$config_file"
 
 #export SDL_AUDIODRIVER=dsp   //disable 20231031 for sound suspend issue
 HOME=$PWD ./PPSSPPSDL_vulkan "$*"


### PR DESCRIPTION
When you mute the volume it sets the GlobalVolume in ppsspp.ini to 0 and it will stay that way when ppsspp is launched even if your audio is not muted.