### PR TITLE
Update FolderOverrideFinder.sh

### DIFF
--- a/System/usr/trimui/scripts/FolderOverrideFinder.sh
+++ b/System/usr/trimui/scripts/FolderOverrideFinder.sh
@@ -1,60 +1,38 @@
-subdir_count=$(echo "$1" | awk -F'/Roms/' '{print $2}' | awk -F'/' '{print NF-1}') # Count the number of slashes in the rest of the path
+#!/bin/sh
+if [ -n "$2" ]; then
+    return
+fi
+
+ROM_PATH=$(realpath "$1")
+rom_path_after_roms=${ROM_PATH#*/Roms/}
+subdir_count=$(echo "$rom_path_after_roms" | grep -o '/' | wc -l)
 
 if [ "$subdir_count" -gt 1 ]; then
-    if [ -z "$2" ]; then # the override config file is not already defined
-        echo "############### Folder Overrride Finder ###############"
-        first_subdir=$(echo "$1" | awk -F'/Roms/' '{print $2}' | cut -d'/' -f1) # Use awk to extract the part of the path after "/mnt/SDCARD/Roms/" to the next "/".
-        echo "Subdirectory from $first_subdir detected !"
+    ROM_DIRECTORY=$(dirname "$ROM_PATH")
+    ROM_FILENAME=$(basename "$1")
+    ROM_FILENAME_NOEXT=${ROM_FILENAME%.*}
+    first_subdir=$(echo "$rom_path_after_roms" | cut -d'/' -f1)
+    SPOOFING_DIRECTORY="/tmp/folderspoof/$ROM_FILENAME_NOEXT/$first_subdir"
+    echo $SPOOFING_DIRECTORY >"/tmp/${ROM_FILENAME}_spoofing_directory.txt"
+    echo "Subdirectory from $first_subdir detected !"
+    mkdir -p "$SPOOFING_DIRECTORY"
+    mount -o bind "$ROM_DIRECTORY" "$SPOOFING_DIRECTORY" >/tmp/txtfolderspoof
 
-        # We try to find the config folder :
-        core_filename=$(grep '^[[:space:]]*HOME=' "$0" | grep '_libretro\.so' | sed -E 's/.*cores\/([^\/]+\.so).*/\1/')  # we find the core filename in the launch script itself
-        core_folder=$(grep -m 1 "$core_filename" /mnt/SDCARD/System/usr/trimui/scripts/core_folders.csv | cut -d';' -f2) # we use a core database which indicates for a core filename the corresponding config path
-        echo "The core folder for $core_filename is: $core_folder"
+    POST_RUN_SCRIPT="/tmp/folderspoof/${ROM_FILENAME_NOEXT}_postrun.sh"
+    {
+        echo "while kill -0 "$$" 2>/dev/null; do"
+        echo "sleep 2"
+        echo "done"
+        echo "sync"
+        echo "umount \"$SPOOFING_DIRECTORY\""
+        echo "if [ \$? = 0 ]; then"
+        echo "rm -rf \"$SPOOFING_DIRECTORY\""
+        echo "fi"
+    } >"$POST_RUN_SCRIPT"
 
-        if [ -f "/mnt/SDCARD/RetroArch/.retrorch/config/$core_folder/$first_subdir.cfg" ]; then
-            FolderOverride="/mnt/SDCARD/RetroArch/.retroarch/config/$core_folder/$first_subdir.cfg"
-        else
-            # we try to find the folder override without the core database
-            result=$(find /mnt/SDCARD/RetroArch/.retroarch/config/ -name "$first_subdir.cfg")
-            num_lines=$(echo "$result" | wc -l)
+    chmod a+x "$POST_RUN_SCRIPT"
+    "$POST_RUN_SCRIPT" &
 
-            if [ $num_lines -eq 1 ]; then
-                FolderOverride="$result"
-            else
-                # if we find multiple folder override config files, we try to find the right one depending the core name
-                core_name=$(grep '^[[:space:]]*HOME=' "$0" | grep '_libretro\.so' | sed -E 's/.*cores\/([^\/]+)_libretro\.so.*/\1/' | cut -d'_' -f1)
-                result=$(echo "$result" | grep -i "$core_name/")
-                num_lines=$(echo "$result" | wc -l)
-                if [ $num_lines -eq 1 ]; then
-                    FolderOverride="$result"
-                else
-                    if [ $num_lines -ne 0 ]; then
-                        # less restrictive comparison  :
-                        result=$(echo "$result" | grep -i "$core_name")
-                        num_lines=$(echo "$result" | wc -l)
-                        if [ $num_lines -eq 1 ]; then
-                            FolderOverride="$result" #  (we avoid to select one by default : FolderOverride=$(echo "$result" | head -n 1))
-                        elif [ $num_lines -gt 1 ]; then
-                            echo "Multiple possibilities found, none selected"
-                        fi
-
-                    fi
-                fi
-            fi
-        fi
-
-        if [ ! -z "$FolderOverride" ]; then
-
-            echo "Folder override found: $FolderOverride"
-            echo "#######################################################"
-            source "$0" "$1" --appendconfig "$FolderOverride"
-            exit
-        else
-            echo "Folder override not found"
-            echo "#######################################################"
-        fi
-
-    fi
-else
-    echo "No subdirectory detected."
+    exec "$0" "$SPOOFING_DIRECTORY/$ROM_FILENAME" "alreadydone"
+    exit
 fi

--- a/System/usr/trimui/scripts/FolderOverrideFinder.sh
+++ b/System/usr/trimui/scripts/FolderOverrideFinder.sh
@@ -3,15 +3,12 @@ if [ -n "$2" ]; then
     return
 fi
 
-ROM_PATH=$(realpath "$1")
-rom_path_after_roms=${ROM_PATH#*/Roms/}
+rom_path_after_roms=${ROM_REAL_PATH#*/Roms/}
 subdir_count=$(echo "$rom_path_after_roms" | grep -o '/' | wc -l)
 
 if [ "$subdir_count" -gt 1 ]; then
-    ROM_DIRECTORY=${ROM_PATH%/*}
+    ROM_DIRECTORY=${ROM_REAL_PATH%/*}
     first_subdir=${rom_path_after_roms%%/*}
-    ROM_FILENAME=$(basename "$1")
-    ROM_FILENAME_NOEXT=${ROM_FILENAME%.*}
     SPOOFING_DIRECTORY="/tmp/folderspoof/$ROM_FILENAME_NOEXT/$first_subdir"
 
     echo "Subdirectory from $first_subdir detected !"

--- a/System/usr/trimui/scripts/FolderOverrideFinder.sh
+++ b/System/usr/trimui/scripts/FolderOverrideFinder.sh
@@ -8,27 +8,31 @@ rom_path_after_roms=${ROM_PATH#*/Roms/}
 subdir_count=$(echo "$rom_path_after_roms" | grep -o '/' | wc -l)
 
 if [ "$subdir_count" -gt 1 ]; then
-    ROM_DIRECTORY=$(dirname "$ROM_PATH")
+    ROM_DIRECTORY=${ROM_PATH%/*}
+    first_subdir=${rom_path_after_roms%%/*}
     ROM_FILENAME=$(basename "$1")
     ROM_FILENAME_NOEXT=${ROM_FILENAME%.*}
-    first_subdir=$(echo "$rom_path_after_roms" | cut -d'/' -f1)
     SPOOFING_DIRECTORY="/tmp/folderspoof/$ROM_FILENAME_NOEXT/$first_subdir"
-    echo $SPOOFING_DIRECTORY >"/tmp/${ROM_FILENAME}_spoofing_directory.txt"
+
     echo "Subdirectory from $first_subdir detected !"
+
     mkdir -p "$SPOOFING_DIRECTORY"
-    mount -o bind "$ROM_DIRECTORY" "$SPOOFING_DIRECTORY" >/tmp/txtfolderspoof
+    mount -o bind "$ROM_DIRECTORY" "$SPOOFING_DIRECTORY"
 
     POST_RUN_SCRIPT="/tmp/folderspoof/${ROM_FILENAME_NOEXT}_postrun.sh"
-    {
-        echo "while kill -0 "$$" 2>/dev/null; do"
-        echo "sleep 2"
-        echo "done"
-        echo "sync"
-        echo "umount \"$SPOOFING_DIRECTORY\""
-        echo "if [ \$? = 0 ]; then"
-        echo "rm -rf \"$SPOOFING_DIRECTORY\""
-        echo "fi"
-    } >"$POST_RUN_SCRIPT"
+    cat <<EOF >"$POST_RUN_SCRIPT"
+while kill -0 "$$" 2>/dev/null; do
+  sleep 2
+done
+sync
+umount "$SPOOFING_DIRECTORY"
+if [ \$? = 0 ]; then
+  sleep 1
+  rmdir "$SPOOFING_DIRECTORY"
+  rmdir "/tmp/folderspoof/$ROM_FILENAME_NOEXT"
+fi
+rm "${POST_RUN_SCRIPT}"
+EOF
 
     chmod a+x "$POST_RUN_SCRIPT"
     "$POST_RUN_SCRIPT" &


### PR DESCRIPTION
## Script purpose and behavior

This script works around RetroArch’s limitation where **Directory Override Configs** (`<folder>.cfg`) only apply to the immediate folder containing the ROM file. Normally, if a ROM is stored inside deeper subfolders (e.g., `Emus/Roms/GB/MyGames/demo.gb`), RetroArch will only create an override config for the last folder (`MyGames.cfg`) rather than the desired platform folder (`GB.cfg`).

The script intercepts the launch process and:

1. **Detects deep ROM paths**  
   - If the ROM is located more than one folder below the `Roms` root, it triggers the spoofing logic.  
   - For example:  
     ```
     Emus/Roms/GB/MyGames/demo.gb
                     ^--- this is the "first_subdir" (GB)
     ```

2. **Creates a spoofed directory structure**  
   - Builds a temporary folder in `/tmp/folderspoof/<rom_name>/<platform_folder>/`  
   - Bind-mounts the actual ROM’s directory to this spoofed path so RetroArch sees the ROM as if it were directly inside the platform’s folder (e.g., `GB/`).

3. **Maintains compatibility with other systems and features**  
   - **Activities app** still sees the real ROM path (not the spoof path), ensuring tracking of play history and time remains correct.  
   - **Directory overrides** now work as intended for configurations, remaps, and shaders because the spoofed directory matches the platform folder name.  
   - **Local save states** (TrimUI in-game menu) work normally since the spoof is transparent at the filesystem level.  
   - **M3U playlists** are supported because the binding is done at the directory level, not just for a single file.  
   - **Multiple simultaneous games** can be launched without interference—each game has its own temporary spoof path and cleanup process.  
   - **Resume at boot** still works since RetroArch’s stored paths resolve back to the same spoofed structure when re-launched.

4. **Cleans up automatically after game exit**  
   - A background post-run script monitors the main process.  
   - Once RetroArch closes the game, it unmounts the bind mount, removes the temporary folders, and deletes the helper script.
