### PR TITLE
[Feature] Preset notifications

### DIFF
--- a/System/usr/trimui/scripts/load_launcher.sh
+++ b/System/usr/trimui/scripts/load_launcher.sh
@@ -5,20 +5,26 @@ EMU_DIR="$(echo "$0" | sed -E 's|(.*Emus/[^/]+)/.*|\1|')"
 ROM_DIR="$(echo "$1" | sed -E 's|(.*Roms/[^/]+)/.*|\1|')"
 GAME=$(basename "$1")
 
-Game_cfg="$ROM_DIR/.games_config/${GAME%.*}.cfg"
-Emu_cfg="$EMU_DIR/launchers.cfg"
+export Game_cfg="$ROM_DIR/.games_config/${GAME%.*}.cfg"
+export Emu_cfg="$EMU_DIR/launchers.cfg"
 
 # Look for a saved preset
 if [ -f "$Game_cfg" ]; then
-    Launcher_name=$(cat "$Game_cfg")
+    export Launcher_name=$(cat "$Game_cfg")
+    export Preset_Type="Game"
+
 elif [ -f "$Emu_cfg" ]; then
-    Launcher_name=$(cat "$Emu_cfg")
+    export Launcher_name=$(cat "$Emu_cfg")
+    export Preset_Type="Emu"
+
 fi
 Launcher_name=${Launcher_name#*=}
 
 if [ -n "$Launcher_name" ]; then
     Launcher_command=$(jq -r --arg name "$Launcher_name" \
         '.launchlist[] | select(.name == $name) | .launch' "$EMU_DIR/config.json")
+    echo -e "{ \"type\":\"info\", \"size\":2, \"duration\":2000, \"x\":660, \"y\":0,  \"message\":\"$Preset_Type preset: $Launcher_name\",  \"icon\":\"\" }" >/tmp/trimui_osd/osd_toast_msg
+
 else
     # Look for the first valid launcher in launchlist
     if jq -e ".launchlist" "$EMU_DIR/config.json" >/dev/null 2>&1; then
@@ -29,18 +35,18 @@ else
         done < <(jq -c '.launchlist[]' "$EMU_DIR/config.json")
     else
         # Else use launch.sh as fallback
-        Launcher_name=Unique
+        Launcher_name=Default
         Launcher_command="launch.sh"
     fi
 fi
 
 echo "load_launcher.sh : $Launcher_name dowork 0x" >>/tmp/log/messages
 {
-rm "/tmp/trimui_osd/slider_cpu_preset/curpreset"
-echo "0/3" > "/tmp/trimui_osd/slider_cpu_preset/status"
+    rm "/tmp/trimui_osd/slider_cpu_preset/curpreset"
+    echo "0/3" >"/tmp/trimui_osd/slider_cpu_preset/status"
 } &
 "$EMU_DIR/$Launcher_command" "$@"
 {
-rm "/tmp/trimui_osd/slider_cpu_preset/curpreset"
-echo "0/3" > "/tmp/trimui_osd/slider_cpu_preset/status"
+    rm "/tmp/trimui_osd/slider_cpu_preset/curpreset"
+    echo "0/3" >"/tmp/trimui_osd/slider_cpu_preset/status"
 } &

--- a/System/usr/trimui/scripts/save_launcher.sh
+++ b/System/usr/trimui/scripts/save_launcher.sh
@@ -14,8 +14,14 @@ save_launcher() {
 }
 
 button_state.sh L
-[ $? -eq 10 ] && save_launcher "$1"
+if [ $? -eq 10 ]; then
+    save_launcher "$1"
+    echo -e "{ \"type\":\"info\", \"size\":2, \"duration\":3000, \"x\":660, \"y\":0,  \"message\":\"Game preset created: $Launcher_name\",  \"icon\":\"\" }" >/tmp/trimui_osd/osd_toast_msg
+fi
 
 # Save launcher as default one
 button_state.sh R
-[ $? -eq 10 ] && save_launcher
+if [ $? -eq 10 ]; then
+    save_launcher
+    echo -e "{ \"type\":\"info\", \"size\":2, \"duration\":3000, \"x\":660, \"y\":0,  \"message\":\"Emu preset created: $Launcher_name\",  \"icon\":\"\" }" >/tmp/trimui_osd/osd_toast_msg
+fi


### PR DESCRIPTION
This update will allows to display OSD notifications:
- when you create a new game preset (game preset or Emu preset).
- when a preset is automatically loaded which the preset type ("Emu" or "Game") and the name of the current preset.

The "Preset_Type" & "Launcher_name" variables in load_launcher.sh created is also used by RomScripts to be able to display the current preset.