### PR TITLE
Fix Broken Release Due To GitHub  File Size Limitations

### DIFF
--- a/.github/workflows/CrossMix Release.yml
+++ b/.github/workflows/CrossMix Release.yml
@@ -47,12 +47,16 @@ jobs:
         run: |
           shopt -s dotglob
           cd /home/runner/work/CrossMix-OS/CrossMix-OS
-          zip -r "/home/runner/work/CrossMix-OS/CrossMix-OS_v${{ env.BUILD_VERSION }}.zip" ./*
+          # Use zip with -s option to split the archive into multiple volumes
+          # Create a 2GB (2000m) split zip file
+          zip -r -s 2000m "/home/runner/work/CrossMix-OS/CrossMix-OS_v${{ env.BUILD_VERSION }}.zip" ./*
       - name: Create Release
         uses: marvinpinto/action-automatic-releases@latest
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           title: "CrossMix-OS v${{ env.BUILD_VERSION }}"
           prerelease: false
-          files: "/home/runner/work/CrossMix-OS/CrossMix-OS_v${{ env.BUILD_VERSION }}.zip"
+          files: |
+            /home/runner/work/CrossMix-OS/CrossMix-OS_v${{ env.BUILD_VERSION }}.zip
+            /home/runner/work/CrossMix-OS/CrossMix-OS_v${{ env.BUILD_VERSION }}.z01
           draft: true


### PR DESCRIPTION
Taken from
https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases#storage-and-bandwidth-quotas:
> Up to 1000 release assets may be associated with a single release. Each file included in a release must be under 2 GiB. There is no limit on the total size of a release, nor bandwidth usage.


* Updated the `zip` command in `.github/workflows/CrossMix Release.yml` to use the `-s 2000m` option, splitting the archive into 2GB volumes for large builds: https://github.com/stefan-ctrl/CrossMix-OS/actions/runs/20720763003
* Modified the release step to include both the main zip file and the first split volume (`.z01`) as release assets, ensuring users can download all necessary parts.
* 
confirmation of solution: https://github.com/stefan-ctrl/CrossMix-OS/actions/runs/20722004661/job/59487942483